### PR TITLE
fix(headless,cli): lib resolution, save schema, potions, Regent stars, play UI, launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ obj/
 .DS_Store
 .obsidian/
 logs/
+saves/*

--- a/launch.py
+++ b/launch.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+sts2-cli 启动器：选择新游戏（角色、进阶）或读取存档，再进入 python/play.py。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+PLAY_PY = os.path.join(ROOT, "python", "play.py")
+SAVE_DIR = os.path.join(ROOT, "saves")
+LOC_CHARS = os.path.join(ROOT, "localization_zhs", "characters.json")
+
+# play.py --character 使用的英文名，顺序与官方角色选择一致
+CLI_CHARACTERS = ["Ironclad", "Silent", "Defect", "Regent", "Necrobinder"]
+
+
+def _load_char_titles() -> dict[str, str]:
+    """官方中文角色名（localization_zhs/characters.json）。"""
+    titles: dict[str, str] = {}
+    if not os.path.isfile(LOC_CHARS):
+        return titles
+    with open(LOC_CHARS, encoding="utf-8") as f:
+        z = json.load(f)
+    for key in ("IRONCLAD", "SILENT", "DEFECT", "REGENT", "NECROBINDER"):
+        titles[key] = z.get(f"{key}.title", key)
+    return titles
+
+
+def _char_zh(titles: dict[str, str], cli_name: str) -> str:
+    return titles.get(cli_name.upper(), cli_name)
+
+
+def _prompt_line(prompt: str) -> str:
+    try:
+        return input(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        raise SystemExit(0) from None
+
+
+def _pick_int(prompt: str, lo: int, hi: int, default: int | None = None) -> int:
+    while True:
+        raw = _prompt_line(prompt)
+        if not raw and default is not None:
+            return default
+        try:
+            v = int(raw)
+        except ValueError:
+            print(f"  请输入 {lo}–{hi} 之间的整数。")
+            continue
+        if lo <= v <= hi:
+            return v
+        print(f"  请输入 {lo}–{hi} 之间的整数。")
+
+
+def _collect_save_entries() -> list[dict]:
+    if not os.path.isdir(SAVE_DIR):
+        return []
+    out: list[dict] = []
+    for name in os.listdir(SAVE_DIR):
+        path = os.path.join(SAVE_DIR, name)
+        if not os.path.isfile(path):
+            continue
+        st = os.stat(path)
+        if name.endswith(".json"):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    d = json.load(f)
+                out.append({
+                    "kind": "replay",
+                    "path": path,
+                    "name": name,
+                    "mtime": st.st_mtime,
+                    "character": d.get("character", "?"),
+                    "seed": d.get("seed", "?"),
+                    "actions": len(d.get("actions", [])),
+                })
+            except (json.JSONDecodeError, OSError):
+                pass
+        elif name.endswith(".save"):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+                seed = data.get("rng", {}).get("seed", "?")
+                asc = data.get("ascension", 0)
+                char_id = "?"
+                pl = data.get("players", [])
+                if pl:
+                    char_id = pl[0].get("character_id", "?")
+                out.append({
+                    "kind": "native",
+                    "path": path,
+                    "name": name,
+                    "mtime": st.st_mtime,
+                    "seed": seed,
+                    "ascension": asc,
+                    "character_id": char_id,
+                })
+            except (json.JSONDecodeError, OSError):
+                out.append({
+                    "kind": "native",
+                    "path": path,
+                    "name": name,
+                    "mtime": st.st_mtime,
+                    "broken": True,
+                })
+    out.sort(key=lambda x: -x["mtime"])
+    return out
+
+
+def _format_entry(titles: dict[str, str], e: dict) -> str:
+    ts = datetime.fromtimestamp(e["mtime"]).strftime("%Y-%m-%d %H:%M")
+    if e["kind"] == "replay":
+        ch = str(e.get("character", "?"))
+        zh = _char_zh(titles, ch)
+        return f"{e['name']}  |  {zh}  |  种子 {e['seed']}  |  {e['actions']} 步  |  {ts}"
+    if e.get("broken"):
+        return f"{e['name']}  |  （文件损坏或无法解析）  |  {ts}"
+    cid = str(e.get("character_id", "?"))
+    zh = titles.get(cid.upper(), cid) if cid != "?" else "?"
+    return (
+        f"{e['name']}  |  {zh}  |  进阶 {e['ascension']}  |  种子 {e['seed']}  |  {ts}"
+    )
+
+
+def _run_play(args: list[str], lang: str) -> int:
+    cmd = [sys.executable, PLAY_PY, "--lang", lang, *args]
+    # play.py 内 ROOT 由文件路径解析，不依赖 cwd；统一设为仓库根目录便于相对路径。
+    r = subprocess.run(cmd, cwd=ROOT)
+    return r.returncode
+
+
+def _menu_new_game(titles: dict[str, str], lang: str) -> None:
+    print("\n── 选择角色 ──")
+    for i, cli in enumerate(CLI_CHARACTERS, 0):
+        zh = _char_zh(titles, cli)
+        print(f"  {i}  {zh}  ({cli})")
+    idx = _pick_int("\n输入编号 (0–4): ", 0, 4)
+    character = CLI_CHARACTERS[idx]
+    asc = _pick_int(
+        "\n进阶等级 0–10（0 为标准模式，直接回车默认为 0）: ",
+        0,
+        10,
+        default=0,
+    )
+    print(f"\n启动：{ _char_zh(titles, character) }  |  进阶 {asc}\n")
+    _run_play(["--character", character, "--ascension", str(asc)], lang)
+
+
+def _menu_load_save(titles: dict[str, str], lang: str) -> None:
+    entries = _collect_save_entries()
+    if not entries:
+        print("\n  saves/ 下没有 .save 或 .json 存档。请先在对局中存档或退出时选择保存。\n")
+        return
+
+    print("\n── 读取存档（按修改时间从新到旧）──")
+    print("  [继续游戏] = 游戏原生 .save")
+    print("  [操作回放] = 对局内 save 命令生成的 .json\n")
+    for i, e in enumerate(entries, 1):
+        tag = "继续游戏" if e["kind"] == "native" else "操作回放"
+        print(f"  {i:2}  [{tag}]  {_format_entry(titles, e)}")
+    print(f"\n  0  返回上一级")
+    choice = _pick_int("\n输入编号: ", 0, len(entries))
+    if choice == 0:
+        return
+    sel = entries[choice - 1]
+    rel = os.path.relpath(sel["path"], ROOT)
+    if sel["kind"] == "native":
+        print(f"\n以继续游戏方式加载：{rel}\n")
+        _run_play(["--continue", rel], lang)
+    else:
+        print(f"\n以操作回放方式加载：{rel}\n")
+        _run_play(["--load", rel], lang)
+
+
+def _main_interactive(lang: str) -> None:
+    sys.path.insert(0, os.path.join(ROOT, "python"))
+    import play as play_mod  # noqa: PLC0415
+
+    play_mod.ensure_setup()
+    titles = _load_char_titles()
+
+    while True:
+        print(
+            f"""
+╔══════════════════════════════════════╗
+║       Slay the Spire 2  CLI          ║
+╚══════════════════════════════════════╝
+
+  1  新游戏
+  2  读取存档
+  0  退出
+"""
+        )
+        c = _prompt_line("请选择 (0–2): ").lower()
+        if c in ("0", "q", "quit", "exit", ""):
+            print("再见。")
+            break
+        if c == "1":
+            _menu_new_game(titles, lang)
+        elif c == "2":
+            _menu_load_save(titles, lang)
+        else:
+            print("  无效输入，请输入 0、1 或 2。")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="sts2-cli 交互式启动器")
+    parser.add_argument(
+        "--lang",
+        choices=["zh", "en", "both"],
+        default="zh",
+        help="交给 play.py 的显示语言",
+    )
+    args = parser.parse_args()
+    _main_interactive(args.lang)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/play.py
+++ b/python/play.py
@@ -21,7 +21,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT = os.path.join(ROOT, "src", "Sts2Headless", "Sts2Headless.csproj")
 LIB_DIR = os.path.join(ROOT, "lib")
 SAVE_DIR = os.path.join(ROOT, "saves")
-CURRENT_SAVE_SCHEMA_VERSION = 14
+
 
 def _find_dotnet():
     """Find .NET SDK binary."""
@@ -369,7 +369,29 @@ def t(en, zh=None):
         return en
     return zh
 
-RARITY_ZH = {"Common": "普通", "Uncommon": "罕见", "Rare": "稀有"}
+# Card rarities — keys match sts2 CardRarity.ToString(); ZHS from localization_zhs/gameplay_ui.json CARD_RARITY.*
+RARITY_ZH = {
+    "Basic": "基础",
+    "Common": "普通",
+    "Uncommon": "罕见",
+    "Rare": "稀有",
+    "Curse": "诅咒",
+    "Status": "状态",
+    "Token": "衍生",
+    "Event": "事件",
+    "Quest": "任务",
+    "Ancient": "先古",
+}
+# Matches localization_zhs/card_keywords.json (display only)
+CARD_KW_ZH = {
+    "Exhaust": "消耗", "Innate": "固有", "Ethereal": "虚无", "Retain": "保留",
+    "Sly": "奇巧", "Eternal": "永恒", "Unplayable": "不能被打出",
+}
+# End of title line (restrictive / rules)
+CARD_KW_SUFFIX_ORDER = ("Exhaust", "Unplayable", "Eternal")
+# Before description as [A/B/C]
+CARD_KW_PREFIX_ORDER = ("Innate", "Ethereal", "Retain", "Sly")
+
 CARD_TYPE_ZH = {"Attack": "攻击", "Skill": "技能", "Power": "能力", "Status": "状态", "Curse": "诅咒"}
 NODE_TYPE_ZH = {"Monster": "怪物", "Elite": "精英", "Boss": "Boss", "RestSite": "休息处",
                 "Shop": "商店", "Treasure": "宝箱", "Event": "事件", "Unknown": "未知", "Ancient": "远古"}
@@ -418,6 +440,118 @@ def card_desc(card):
     stats = card.get("stats") or {}
     return resolve_template(d, stats)  # always resolve (handles energyPrefix etc.)
 
+
+def _card_kw_label(kw):
+    return t(kw, CARD_KW_ZH.get(kw, kw))
+
+
+def split_card_keywords(keywords):
+    """Split into (prefix, suffix) for layout; uses live ``keywords`` from state each call."""
+    raw = [k for k in (keywords or []) if k]
+    if not raw:
+        return [], []
+    suffix_set = set(CARD_KW_SUFFIX_ORDER)
+    suffix = [k for k in raw if k in suffix_set]
+    prefix_rest = [k for k in raw if k not in suffix_set]
+
+    prefix_ordered = []
+    used = set()
+    for k in CARD_KW_PREFIX_ORDER:
+        if k in prefix_rest:
+            prefix_ordered.append(k)
+            used.add(k)
+    for k in prefix_rest:
+        if k not in used:
+            prefix_ordered.append(k)
+            used.add(k)
+
+    suffix_ordered = sorted(suffix, key=lambda k: CARD_KW_SUFFIX_ORDER.index(k))
+    return prefix_ordered, suffix_ordered
+
+
+def format_card_suffix_keywords(suffix_list):
+    if not suffix_list:
+        return ""
+    inner = " ".join(c(_card_kw_label(k), "dim") for k in suffix_list)
+    return f" [{inner}]"
+
+
+def format_card_prefix_tag(prefix_list):
+    if not prefix_list:
+        return ""
+    return "[" + "/".join(_card_kw_label(k) for k in prefix_list) + "]"
+
+
+def card_description_display_lines(card):
+    """Lines under the title row; [前缀词条] merges into first line, then remaining loc lines."""
+    cd_d = card_desc(card)
+    prefix, _suf = split_card_keywords(card.get("keywords"))
+    tag = format_card_prefix_tag(prefix)
+    if not cd_d:
+        return [tag] if tag else []
+
+    lines = [ln.strip() for ln in cd_d.split("\n") if ln.strip()]
+    if not lines:
+        return [tag] if tag else []
+
+    if len(lines) == 1:
+        return [f"{tag}{lines[0]}" if tag else lines[0]]
+
+    out = []
+    if tag:
+        out.append(f"{tag}{lines[0]}")
+        out.extend(lines[1:])
+    else:
+        out.extend(lines)
+    return out
+
+
+def combat_hand_inline_stat_str(stats, *, card=None, osty=None):
+    """Title-row 伤/挡 from RunSimulator ``stats`` (DynamicVars, keys lowercased).
+
+    Plain ``damage`` is used for Strike-like cards; many attacks use ``calculateddamage``
+    or companion hits use ``ostydamage``. Some Necrobinder cards add Osty HP to the card
+    total in text but only expose the base in ``stats``—merge using combat ``osty`` blob.
+    """
+    if not stats:
+        stats = {}
+    parts = []
+    cid = (card or {}).get("id") or ""
+    osty_ok = bool(osty and osty.get("alive"))
+
+    dmg = None
+    if cid == "CARD.UNLEASH" and osty_ok:
+        base = stats.get("calculateddamage")
+        if base is None:
+            base = stats.get("damage")
+        if base is not None:
+            hp = osty.get("hp")
+            dmg = int(base) + int(hp) if isinstance(hp, (int, float)) else int(base)
+    elif cid == "CARD.PROTECTOR" and osty_ok:
+        base = stats.get("calculateddamage")
+        if base is None:
+            base = stats.get("damage")
+        if base is not None:
+            mhp = osty.get("max_hp")
+            dmg = int(base) + int(mhp) if isinstance(mhp, (int, float)) else int(base)
+
+    if dmg is None:
+        v = stats.get("damage")
+        if v is None:
+            v = stats.get("calculateddamage")
+        if v is None:
+            v = stats.get("ostydamage")
+        if v is not None:
+            dmg = int(v)
+
+    if dmg is not None:
+        parts.append(c(f"{dmg}{t('dmg','伤')}", "red"))
+    blk = stats.get("block")
+    if blk is not None:
+        parts.append(c(f"{blk}{t('blk','挡')}", "blue"))
+    return " ".join(parts)
+
+
 def relic_str(r):
     """Format a relic with name and resolved description."""
     if isinstance(r, dict) and "name" in r:
@@ -459,21 +593,15 @@ def show_player(p, show_deck=False):
         cards = p.get("deck", [])
         if cards:
             print(f"  {c(t('Deck:','牌组:'), 'bold')}")
-            KW_ZH = {"Exhaust": "消耗", "Innate": "固有", "Ethereal": "虚无", "Retain": "保留", "Sly": "奇巧", "Eternal": "永恒", "Unplayable": "不能被打出"}
             for cd in cards:
                 up = c("+", "green") if cd.get("upgraded") else ""
                 ctype_zh = CARD_TYPE_ZH.get(cd.get("type",""), cd.get("type",""))
-                kws = cd.get("keywords") or []
-                kw_str = " ".join(c(t(k, KW_ZH.get(k, k)), "dim") for k in kws)
-                kw_str = f" [{kw_str}]" if kw_str else ""
-                cd_d = card_desc(cd)
-                print(f"    {n(cd['name'])}{up} ({cd.get('cost','?')}) {c(t(cd.get('type',''), ctype_zh), 'dim')}{kw_str}")
-                if cd_d:
-                    print(f"      {c(cd_d, 'dim')}")
-                stats = cd.get("stats") or {}
-                aug_parts = _format_upgrade_preview(stats, cd.get("after_upgrade"), cd.get("cost"))
-                if aug_parts:
-                    print(f"      {c(t('upgrade:','升级:'), 'green')} {', '.join(aug_parts)}")
+                _pre, suf = split_card_keywords(cd.get("keywords"))
+                suf_part = format_card_suffix_keywords(suf)
+                rare = cd.get("rarity")
+                rare_part = f" {c(t(rare, RARITY_ZH.get(rare, rare)), 'dim')}" if rare else ""
+                print(f"    {n(cd['name'])}{up} ({cd.get('cost','?')}) {c(t(cd.get('type',''), ctype_zh), 'dim')}{rare_part}{suf_part}")
+                print_card_detail_extension(cd, indent="      ")
 
 def show_combat(state):
     rnd = state.get("round", 0)
@@ -606,35 +734,20 @@ def show_combat(state):
         if star_cost > 0:
             cost_str += f"+{c(f'{star_cost}⭐', 'yellow')}"
 
-        # Show damage/block inline, plus description for non-trivial cards
-        stats = card.get("stats") or {}
-        stat_parts = []
-        if "damage" in stats: stat_parts.append(c(f"{stats['damage']}{t('dmg','伤')}", "red"))
-        if "block" in stats: stat_parts.append(c(f"{stats['block']}{t('blk','挡')}", "blue"))
-        stat_str = " ".join(stat_parts)
+        # Damage/block inline on title row; suffix keywords (e.g. 消耗) at end of title row
+        stat_str = combat_hand_inline_stat_str(
+            card.get("stats") or {}, card=card, osty=state.get("osty")
+        )
 
-        # Show description if card has no damage/block (so effect isn't obvious from stats)
-        cd_d = card_desc(card)
-        extra_desc = ""
-        if cd_d and "damage" not in stats and "block" not in stats:
-            # No damage/block — show full description inline
-            extra_desc = f"  {c(cd_d.replace(chr(10), ' '), 'dim')}"
-        elif cd_d and any(k not in ("damage", "block") for k in stats):
-            # Has extra effects beyond damage/block — show last line
-            lines = cd_d.split("\n")
-            if len(lines) > 1:
-                extra_desc = f"  {c(lines[-1], 'dim')}"
-
-        # Show keywords (Innate, Exhaust, Ethereal, etc.)
-        KW_ZH = {"Exhaust": "消耗", "Innate": "固有", "Ethereal": "虚无", "Retain": "保留", "Sly": "奇巧", "Eternal": "永恒", "Unplayable": "不能被打出"}
-        kws = card.get("keywords") or []
-        kw_str = " ".join(c(t(k, KW_ZH.get(k, k)), "dim") for k in kws) if kws else ""
-        if kw_str: kw_str = f" [{kw_str}]"
+        _pre, suf = split_card_keywords(card.get("keywords"))
+        suf_part = format_card_suffix_keywords(suf)
         ench = card.get("enchantment")
         ench_str = f" {c(n(ench), 'magenta')}" if ench else ""
 
-        print(f"  {mark} [{card['index']}] {c(n(card['name']), type_color)}{ench_str} ({cost_str}) {stat_str}{kw_str}{extra_desc}"
+        print(f"  {mark} [{card['index']}] {c(n(card['name']), type_color)}{ench_str} ({cost_str}) {stat_str}{suf_part}"
               + (f"  {c('→','yellow')}" if target == "AnyEnemy" else ""))
+
+        print_card_detail_extension(card, indent="      ")
 
 def show_map(state, send_fn=None):
     """Show map at map_select. Fetches full map if send_fn available."""
@@ -691,12 +804,34 @@ def _format_upgrade_preview(stats, aug, current_cost=None):
             else:
                 parts.append(c(f"{old}→{new_val}", "green"))
     # Keyword changes (e.g., Discovery removes Exhaust)
-    KW_ZH = {"Exhaust": "消耗", "Innate": "固有", "Ethereal": "虚无", "Retain": "保留", "Sly": "奇巧", "Eternal": "永恒", "Unplayable": "不能被打出"}
     for kw in (aug.get("removed_keywords") or []):
-        parts.append(c(f"-{t(kw, KW_ZH.get(kw, kw))}", "green"))
+        parts.append(c(f"-{_card_kw_label(kw)}", "green"))
     for kw in (aug.get("added_keywords") or []):
-        parts.append(c(f"+{t(kw, KW_ZH.get(kw, kw))}", "yellow"))
+        parts.append(c(f"+{_card_kw_label(kw)}", "yellow"))
     return parts
+
+
+def print_card_detail_extension(card, indent="      "):
+    """Description (with [prefix/keywords]) + upgrade preview; indent matches title row spacing."""
+    for line in card_description_display_lines(card):
+        if line:
+            print(f"{indent}{c(line, 'dim')}")
+    stats = card.get("stats") or {}
+    aug_parts = _format_upgrade_preview(stats, card.get("after_upgrade"), card.get("cost"))
+    if aug_parts:
+        print(f"{indent}{c(t('upgrade:','升级:'), 'green')} {', '.join(aug_parts)}")
+
+
+def card_pick_quantity_hint(mn, mx):
+    """Short hint for prompts / help (N–M cards)."""
+    if mn == mx:
+        if mn == 1:
+            return t("pick 1 card", "选 1 张")
+        return t(f"pick exactly {mn} cards", f"须选 {mn} 张")
+    if mn == 0:
+        return t(f"pick 0–{mx} cards (or s to skip)", f"可选 0–{mx} 张（或 s 跳过）")
+    return t(f"pick {mn}–{mx} cards", f"须选 {mn}–{mx} 张")
+
 
 def show_card_reward(state):
     print(f"\n{'─' * 60}")
@@ -706,7 +841,8 @@ def show_card_reward(state):
     print(f"  {c(t('Card Reward','卡牌奖励'), 'bold')} — {t('choose one (or skip)','选一张（或跳过）')}")
     show_player(state.get("player", {}))
     print()
-    for card in state.get("cards", []):
+    cards = state.get("cards", [])
+    for card in cards:
         ctype = card.get("type", "?")
         rarity = card.get("rarity", "Common")
         cost = card.get("cost", "?")
@@ -714,16 +850,17 @@ def show_card_reward(state):
         rarity_zh = RARITY_ZH.get(rarity, rarity)
         rarity_label = t(rarity, rarity_zh)
         rarity_color = {"Rare": "yellow", "Uncommon": "cyan"}.get(rarity, "dim")
-        stats = card.get("stats") or {}
-        cd_desc = card_desc(card)
+        _pre, suf = split_card_keywords(card.get("keywords"))
+        suf_part = format_card_suffix_keywords(suf)
+        print(f"  [{card['index']}] {c(n(card['name']), type_color)} ({cost}) {c(rarity_label, rarity_color)}{suf_part}")
+        print_card_detail_extension(card, indent="      ")
 
-        print(f"  [{card['index']}] {c(n(card['name']), type_color)} ({cost}) {c(rarity_label, rarity_color)}")
-        if cd_desc:
-            print(f"      {c(cd_desc, 'dim')}")
-        # Show upgrade preview
-        aug_parts = _format_upgrade_preview(stats, card.get("after_upgrade"), card.get("cost"))
-        if aug_parts:
-            print(f"      {c(t('upgrade:','升级:'), 'green')} {', '.join(aug_parts)}")
+    print()
+    if cards:
+        hi = len(cards) - 1
+        print(f"  {c(t(f'Pick one card: type index 0–{hi}, or s to skip.', f'请选择一张：输入编号 0–{hi}，或 s 跳过。'), 'yellow')}")
+    else:
+        print(f"  {c(t('No cards to pick.', '没有可选卡牌。'), 'dim')}")
 
 def show_shop(state):
     print(f"\n{'─' * 60}")
@@ -739,13 +876,10 @@ def show_shop(state):
         sale = c(t(" SALE"," 打折"), "yellow") if card.get("on_sale") else ""
         ctype_zh = CARD_TYPE_ZH.get(card.get("type",""), card.get("type",""))
         cc = card.get("card_cost", "?")
-        print(f"  [{card['index']}] {n(card['name'])} ({cc}) {c(t(card.get('type','?'), ctype_zh), 'dim')} — {affordable}{t('g','金')}{sale}")
-        cd_desc = card_desc(card)
-        if cd_desc:
-            print(f"      {c(cd_desc, 'dim')}")
-        aug_parts = _format_upgrade_preview(card.get("stats") or {}, card.get("after_upgrade"), card.get("card_cost"))
-        if aug_parts:
-            print(f"      {c(t('upgrade:','升级:'), 'green')} {', '.join(aug_parts)}")
+        _pre, suf = split_card_keywords(card.get("keywords"))
+        suf_part = format_card_suffix_keywords(suf)
+        print(f"  [{card['index']}] {n(card['name'])} ({cc}) {c(t(card.get('type','?'), ctype_zh), 'dim')}{suf_part} — {affordable}{t('g','金')}{sale}")
+        print_card_detail_extension(card, indent="      ")
 
     print(f"\n  {c(t('Relics:','遗物:'), 'bold')}")
     for r in state.get("relics", []):
@@ -1064,8 +1198,12 @@ def _draw_conn(buf, from_col, to_col, W):
         if 0 <= mid < len(buf):
             buf[mid] = ch
 
-def get_input(prompt, valid_options=None, state=None):
-    """Get user input with validation. Supports meta-commands: help, map, deck, potions."""
+def get_input(prompt, valid_options=None, state=None, multi_select=False, multi_min=1, multi_max=1):
+    """Get user input with validation. Supports meta-commands: help, map, deck, potions.
+
+    If multi_select is True, accept comma-separated tokens; each must be in valid_options,
+    and the count must be between multi_min and multi_max (inclusive).
+    """
     while True:
         try:
             raw = input(f"\n{c('>', 'green')} {prompt}: ").strip().lower()
@@ -1093,6 +1231,7 @@ def get_input(prompt, valid_options=None, state=None):
     地图:    输入路径编号 (0, 1, 2)
     战斗:    卡牌编号 / {c('e', 'yellow')} 结束回合 / {c('p0', 'yellow')} 使用药水
     奖励:    卡牌编号 / {c('s', 'yellow')} 跳过
+    多选:    按提示选择张数（须选 N–M 张 / 可选 0–M 张等），编号逗号分隔，例如 {c('0,1,2', 'yellow')}
     休息:    选项编号
     事件:    选项编号 / {c('leave', 'yellow')} 离开
     商店:    {c('c0', 'yellow')} 买卡 / {c('r0', 'yellow')} 遗物 / {c('p0', 'yellow')} 药水 / {c('rm', 'yellow')} 移除 / {c('leave', 'yellow')} 离开
@@ -1114,6 +1253,7 @@ def get_input(prompt, valid_options=None, state=None):
     Map:     path number (0, 1, 2)
     Combat:  card index / {c('e', 'yellow')} end turn / {c('p0', 'yellow')} use potion
     Reward:  card index / {c('s', 'yellow')} skip
+    Multi:   when prompted for N–M cards (or 0–M optional), comma-separate indices, e.g. {c('0,1,2', 'yellow')}
     Rest:    option index
     Event:   option index / {c('leave', 'yellow')} leave
     Shop:    {c('c0', 'yellow')} card / {c('r0', 'yellow')} relic / {c('p0', 'yellow')} potion / {c('rm', 'yellow')} remove / {c('leave', 'yellow')} leave
@@ -1173,9 +1313,29 @@ def get_input(prompt, valid_options=None, state=None):
                 raise KeyboardInterrupt("abandon")
             continue
 
-        if valid_options and raw not in valid_options:
-            print(f"  {t('Invalid. Options:','无效。选项:')} {', '.join(sorted(valid_options))}")
-            continue
+        if valid_options:
+            if multi_select and multi_max > 1:
+                if multi_min == 0 and raw == "s" and "s" in valid_options:
+                    return raw
+                parts = [p.strip() for p in raw.split(",") if p.strip()]
+                if not parts:
+                    print(f"  {t('Invalid. Options:','无效。选项:')} {', '.join(sorted(valid_options))}")
+                    continue
+                if len(parts) < multi_min or len(parts) > multi_max:
+                    q = card_pick_quantity_hint(multi_min, multi_max)
+                    print(f"  {q} — {t(f'Use {multi_min}-{multi_max} comma-separated indices (e.g. 0,1).', f'逗号分隔输入 {multi_min}–{multi_max} 个编号（例 0,1）。')}")
+                    continue
+                if len(parts) != len(set(parts)):
+                    print(f"  {t('Duplicate indices.','编号重复。')}")
+                    continue
+                bad = [p for p in parts if p not in valid_options]
+                if bad:
+                    print(f"  {t('Invalid. Options:','无效。选项:')} {', '.join(sorted(valid_options))}")
+                    continue
+                return ",".join(parts)
+            if raw not in valid_options:
+                print(f"  {t('Invalid. Options:','无效。选项:')} {', '.join(sorted(valid_options))}")
+                continue
         return raw
 
 # ─── Main game loop ───
@@ -1322,9 +1482,13 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
             print("Failed to start simulator")
             return
 
+        game_lang = "en" if LANG == "en" else "zh"
         if native_save_path:
             print(f"  {t('Loading game save...','加载游戏存档...')}")
-            state = send({"cmd": "load_save", "path": native_save_path}, record=False)
+            state = send(
+                {"cmd": "load_save", "path": native_save_path, "lang": game_lang},
+                record=False,
+            )
             if state and state.get("type") == "error":
                 print(f"  {c(t('Error:','错误:'), 'red')} {state.get('message', '?')}")
                 return
@@ -1335,7 +1499,6 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
             print(f"  {c(t('Save loaded!','存档加载成功!'), 'green')}")
         else:
             # Map display lang to game engine lang: "both" falls back to "zh".
-            game_lang = "en" if LANG == "en" else "zh"
             state = send({
                 "cmd": "start_run",
                 "character": character,
@@ -1343,6 +1506,9 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                 "ascension": ascension,
                 "lang": game_lang,
             }, record=False)
+            if state and state.get("type") == "error":
+                print(f"  {c(t('Error:','错误:'), 'red')} {state.get('message', '?')}")
+                return
 
             # Replay saved actions silently
             if replay_actions:
@@ -1490,11 +1656,15 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     # Use potion
                     pidx = int(choice[1:])
                     args = {"potion_index": pidx}
-                    # Ask for target if needed
-                    if enemies:
-                        tgt = get_input("Target enemy [index] or self (s)", state=state)
-                        if tgt != "s" and tgt.isdigit():
-                            args["target_index"] = int(tgt)
+                    pots = state.get("player", {}).get("potions", [])
+                    pot_meta = next((p for p in pots if p and p.get("index") == pidx), None)
+                    if pot_meta and pot_meta.get("target_type") == "AnyEnemy" and enemies:
+                        tgt = get_input(
+                            t("Target enemy [index]", "选择敌人 [编号]"),
+                            {str(e["index"]) for e in enemies},
+                            state=state,
+                        )
+                        args["target_index"] = int(tgt)
                     state = send({"cmd": "action", "action": "use_potion", "args": args})
                 else:
                     card = valid[choice]
@@ -1519,7 +1689,11 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                 if auto:
                     choice = "0" if cards else "s"
                 else:
-                    choice = get_input(t("Pick card [index] or (s)kip", "选择卡牌 [编号] 或 (s)跳过"), set(valid.keys()), state=state)
+                    choice = get_input(
+                        t("Reward: card index 0–n or (s)kip — see list above", "卡牌奖励：输入编号（见上方）或 (s)跳过"),
+                        set(valid.keys()),
+                        state=state,
+                    )
 
                 if choice == "s":
                     state = send({"cmd": "action", "action": "skip_card_reward"})
@@ -1540,10 +1714,10 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     bidx = b["index"]
                     print(f"  {c(f'Pack [{bidx}]:', 'yellow')}")
                     for cd in b.get("cards", []):
-                        cd_desc = card_desc(cd)
-                        print(f"    {n(cd['name'])} ({cd.get('cost','?')}) {c(cd.get('type',''), 'dim')}")
-                        if cd_desc:
-                            print(f"      {c(cd_desc, 'dim')}")
+                        _p, sf = split_card_keywords(cd.get("keywords"))
+                        sp = format_card_suffix_keywords(sf)
+                        print(f"    {n(cd['name'])} ({cd.get('cost','?')}) {c(cd.get('type',''), 'dim')}{sp}")
+                        print_card_detail_extension(cd, indent="      ")
                 valid = {str(b["index"]): b for b in bundles}
                 if auto:
                     choice = "0"
@@ -1559,22 +1733,20 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     print(f"  {c(n(ctx.get('act_name','?')), 'dim')} {t('Floor','层')} {ctx.get('floor','?')}")
                 min_sel = state.get("min_select", 1)
                 max_sel = state.get("max_select", 1)
-                print(f"  {c(t('Choose cards','选择卡牌'), 'bold')} ({t('select','选择')} {min_sel}-{max_sel})")
+                print(f"  {c(t('Choose cards','选择卡牌'), 'bold')} — {card_pick_quantity_hint(min_sel, max_sel)}")
                 show_player(state.get("player", {}))
                 print()
                 cards = state.get("cards", [])
                 for cd in cards:
                     up = c("+", "green") if cd.get("upgraded") else ""
-                    stats = cd.get("stats") or {}
                     ctype_zh = CARD_TYPE_ZH.get(cd.get("type", ""), cd.get("type", ""))
                     ctype_label = t(cd.get("type", ""), ctype_zh)
-                    cd_desc_text = card_desc(cd)
-                    print(f"  [{cd['index']}] {n(cd['name'])}{up} ({cd.get('cost','?')}) {c(ctype_label, 'dim')}")
-                    if cd_desc_text:
-                        print(f"      {c(cd_desc_text, 'dim')}")
-                    aug_parts = _format_upgrade_preview(stats, cd.get("after_upgrade"), cd.get("cost"))
-                    if aug_parts:
-                        print(f"      {c(t('upgrade:','升级:'), 'green')} {', '.join(aug_parts)}")
+                    rare = cd.get("rarity")
+                    rare_part = f" {c(t(rare, RARITY_ZH.get(rare, rare)), 'dim')}" if rare else ""
+                    _p, sf = split_card_keywords(cd.get("keywords"))
+                    sp = format_card_suffix_keywords(sf)
+                    print(f"  [{cd['index']}] {n(cd['name'])}{up} ({cd.get('cost','?')}) {c(ctype_label, 'dim')}{rare_part}{sp}")
+                    print_card_detail_extension(cd, indent="      ")
 
                 valid = {str(cd["index"]): cd for cd in cards}
                 if min_sel == 0:
@@ -1584,9 +1756,23 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                 old_deck_cards = [n(cd.get("name","?")) for cd in state.get("player",{}).get("deck",[])]
 
                 if auto:
-                    choice = "0"
+                    if not cards:
+                        choice = "s" if min_sel == 0 else "0"
+                    else:
+                        n_pick = min(max_sel, len(cards))
+                        n_pick = max(n_pick, min(min_sel, len(cards)))
+                        choice = ",".join(str(cards[i]["index"]) for i in range(n_pick))
                 else:
-                    choice = get_input(t("Choose card(s) [index] or (s)kip", "选择卡牌 [编号] 或 (s)跳过"), set(valid.keys()), state=state)
+                    multi = max_sel > 1 or min_sel > 1
+                    qhint = card_pick_quantity_hint(min_sel, max_sel)
+                    choice = get_input(
+                        t(f"Card indices, comma — {qhint} or (s)kip", f"卡牌编号逗号分隔 — {qhint}，或 (s)跳过"),
+                        set(valid.keys()),
+                        state=state,
+                        multi_select=multi,
+                        multi_min=min_sel,
+                        multi_max=max_sel,
+                    )
 
                 if choice == "s":
                     state = send({"cmd": "action", "action": "skip_select"})

--- a/src/Sts2Headless/Program.cs
+++ b/src/Sts2Headless/Program.cs
@@ -14,6 +14,31 @@ class Program
         WriteIndented = false,
     };
 
+    /// <summary>
+    /// Locate the directory containing sts2.dll: STS2_LIB env, walk up from BaseDirectory, then BaseDirectory/lib.
+    /// </summary>
+    private static string ResolveLibDirectory()
+    {
+        var envLib = Environment.GetEnvironmentVariable("STS2_LIB");
+        if (!string.IsNullOrWhiteSpace(envLib))
+        {
+            var p = Path.GetFullPath(envLib.Trim());
+            if (Directory.Exists(p) && File.Exists(Path.Combine(p, "sts2.dll")))
+                return p;
+        }
+
+        var dir = AppContext.BaseDirectory;
+        for (var depth = 0; depth < 16 && !string.IsNullOrEmpty(dir); depth++)
+        {
+            var candidate = Path.Combine(dir, "lib");
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, "sts2.dll")))
+                return Path.GetFullPath(candidate);
+            dir = Directory.GetParent(dir)?.FullName ?? "";
+        }
+
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "lib"));
+    }
+
     static void Main(string[] args)
     {
         // Prevent unhandled exceptions from crashing the process
@@ -27,10 +52,7 @@ class Program
             e.SetObserved();
         };
 
-        // Set up assembly resolution to find game DLLs
-        var libDir = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "lib");
-        if (!Directory.Exists(libDir))
-            libDir = Path.Combine(AppContext.BaseDirectory, "lib");
+        var libDir = ResolveLibDirectory();
 
         AssemblyLoadContext.Default.Resolving += (ctx, name) =>
         {
@@ -133,7 +155,8 @@ class Program
                 }
                 if (saveJson == null)
                     return new Dictionary<string, object?> { ["type"] = "error", ["message"] = "Provide 'path' or 'json' for load_save" };
-                return sim.LoadSave(saveJson);
+                var loadLang = cmd.TryGetProperty("lang", out var le) ? (le.GetString() ?? "en") : "en";
+                return sim.LoadSave(saveJson, loadLang);
             }
             case "get_map":
                 return sim.GetFullMap();

--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -187,7 +187,10 @@ internal class LocLookup
 /// </summary>
 public class RunSimulator
 {
-    private const int CurrentSaveSchemaVersion = 14;
+    private static int _expectedSaveSchemaVersion;
+    private static bool _expectedSaveSchemaVersionReady;
+    private static readonly object _expectedSaveSchemaVersionLock = new();
+
     private RunState? _runState;
     private static bool _modelDbInitialized;
     private static readonly InlineSynchronizationContext _syncCtx = new();
@@ -462,10 +465,11 @@ public class RunSimulator
     }
 
     // ─── Game actions ───
-    public Dictionary<string, object?> LoadSave(string saveJson)
+    public Dictionary<string, object?> LoadSave(string saveJson, string lang = "en")
     {
         try
         {
+            _loc.Lang = lang;
             EnsureModelDbInitialized();
 
             Log("Loading save file...");
@@ -549,6 +553,105 @@ public class RunSimulator
         }
     }
 
+    /// <summary>
+    /// Expected run save <c>schema_version</c> (lazy: first load_save only, so StartRun never fails on reflection).
+    /// Order: <c>STS2_SAVE_SCHEMA_VERSION</c> env → reflect sts2.dll → fallback with stderr warning.
+    /// </summary>
+    private static int GetExpectedSaveSchemaVersion()
+    {
+        if (_expectedSaveSchemaVersionReady)
+            return _expectedSaveSchemaVersion;
+        lock (_expectedSaveSchemaVersionLock)
+        {
+            if (_expectedSaveSchemaVersionReady)
+                return _expectedSaveSchemaVersion;
+            _expectedSaveSchemaVersion = ResolveExpectedSaveSchemaVersion();
+            _expectedSaveSchemaVersionReady = true;
+            return _expectedSaveSchemaVersion;
+        }
+    }
+
+    private static int ResolveExpectedSaveSchemaVersion()
+    {
+        var env = Environment.GetEnvironmentVariable("STS2_SAVE_SCHEMA_VERSION");
+        if (!string.IsNullOrWhiteSpace(env) && int.TryParse(env.Trim(), out var envVer))
+            return envVer;
+
+        var reflected = TryReflectLatestSaveSchemaVersion();
+        if (reflected.HasValue)
+            return reflected.Value;
+
+        const int fallback = 16;
+        Console.Error.WriteLine(
+            "[Sts2Headless] Could not read save schema from sts2.dll; using fallback " + fallback +
+            ". Set STS2_SAVE_SCHEMA_VERSION or update game DLL / resolver.");
+        return fallback;
+    }
+
+    /// <summary>Find static parameterless GetLatestSchemaVersion (or close) on sts2; supports int/uint/long.</summary>
+    private static int? TryReflectLatestSaveSchemaVersion()
+    {
+        var asm = typeof(SerializableRun).Assembly;
+        Type[] types;
+        try
+        {
+            types = asm.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t != null).Cast<Type>().ToArray();
+        }
+
+        var candidates = new List<(int score, string typeName, int value)>();
+        foreach (var t in types)
+        {
+            MethodInfo? m;
+            try
+            {
+                foreach (var name in new[] { "GetLatestSchemaVersion", "GetLatestVersion" })
+                {
+                    m = t.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                        null, Type.EmptyTypes, null);
+                    if (m == null) continue;
+                    var tn = t.FullName ?? "";
+                    // Avoid unrelated static GetLatestVersion() elsewhere in the assembly.
+                    if (name == "GetLatestVersion" && !tn.Contains("Saves", StringComparison.Ordinal))
+                        continue;
+
+                    var conv = TryConvertSchemaNumber(m.Invoke(null, null));
+                    if (!conv.HasValue) continue;
+
+                    var score = name == "GetLatestSchemaVersion" ? 100 : 0;
+                    if (tn.Contains("Saves", StringComparison.Ordinal)) score += 50;
+                    if (tn.Contains("Schema", StringComparison.Ordinal) || tn.Contains("Migration", StringComparison.Ordinal))
+                        score += 25;
+                    candidates.Add((score, tn, conv.Value));
+                }
+            }
+            catch
+            {
+                // type may not support full reflection on this runtime
+            }
+        }
+
+        if (candidates.Count == 0)
+            return null;
+
+        var best = candidates.OrderByDescending(c => c.score).ThenBy(c => c.typeName).First();
+        return best.value;
+    }
+
+    private static int? TryConvertSchemaNumber(object? value) => value switch
+    {
+        int i => i,
+        uint u => u <= int.MaxValue ? (int)u : null,
+        long l => l >= int.MinValue && l <= int.MaxValue ? (int)l : null,
+        short s => s,
+        ushort us => us,
+        byte b => b,
+        _ => null,
+    };
+
     private static bool ValidateSaveSchemaVersion(string saveJson, out string error)
     {
         error = "";
@@ -570,9 +673,10 @@ public class RunSimulator
                 return false;
             }
 
-            if (schemaVersion != CurrentSaveSchemaVersion)
+            var expected = GetExpectedSaveSchemaVersion();
+            if (schemaVersion != expected)
             {
-                error = $"expected v{CurrentSaveSchemaVersion}, got v{schemaVersion}";
+                error = $"expected v{expected}, got v{schemaVersion}";
                 return false;
             }
 
@@ -710,7 +814,7 @@ public class RunSimulator
             Log($"Serialized save: {saveJson.Length} chars");
 
             var dir = System.IO.Path.GetDirectoryName(outputPath);
-            if (!string.IsNullOrEmpty(dir) && !System.IO.Directory.Exists(dir))
+            if (!string.IsNullOrEmpty(dir))
                 System.IO.Directory.CreateDirectory(dir);
             System.IO.File.WriteAllText(outputPath, saveJson);
             Log($"Save written to: {outputPath}");
@@ -1355,6 +1459,11 @@ public class RunSimulator
             RunManager.Instance.ActionQueueSet.EnqueueWithoutSynchronizing(action);
             WaitForActionExecutor();
             _syncCtx.Pump();
+
+            // Effect may require card_select before the potion slot clears — do not discard as "stuck".
+            if (_cardSelector.HasPending || _cardSelector.HasPendingReward)
+                return DetectDecisionPoint();
+
             // Verify potion was consumed
             var afterPotions = player.Potions?.ToList() ?? new();
             if (afterPotions.Contains(potion))
@@ -1564,13 +1673,16 @@ public class RunSimulator
                 {
                     var stats = new Dictionary<string, object?>();
                     try { foreach (var dv in card.DynamicVars.Values) stats[dv.Name.ToLowerInvariant()] = (int)dv.BaseValue; } catch { }
+                    var bkws = card.Keywords?.Where(k => k != CardKeyword.None).Select(k => k.ToString()).ToList();
                     return new Dictionary<string, object?>
                     {
                         ["name"] = _loc.Card(card.Id.Entry),
                         ["cost"] = card.EnergyCost?.GetResolved() ?? 0,
                         ["type"] = card.Type.ToString(),
+                        ["rarity"] = card.Rarity.ToString(),
                         ["description"] = _loc.Bilingual("cards", card.Id.Entry + ".description"),
                         ["stats"] = stats.Count > 0 ? stats : null,
+                        ["keywords"] = bkws?.Count > 0 ? bkws : null,
                     };
                 }).ToList(),
             }).ToList();
@@ -1593,6 +1705,7 @@ public class RunSimulator
             {
                 var stats = new Dictionary<string, object?>();
                 try { foreach (var dv in cr.Card.DynamicVars.Values) stats[dv.Name.ToLowerInvariant()] = (int)dv.BaseValue; } catch { }
+                var rrkws = cr.Card.Keywords?.Where(k => k != CardKeyword.None).Select(k => k.ToString()).ToList();
                 return new Dictionary<string, object?>
                 {
                     ["index"] = i,
@@ -1603,6 +1716,7 @@ public class RunSimulator
                     ["rarity"] = cr.Card.Rarity.ToString(),
                     ["description"] = _loc.Bilingual("cards", cr.Card.Id.Entry + ".description"),
                     ["stats"] = stats.Count > 0 ? stats : null,
+                    ["keywords"] = rrkws?.Count > 0 ? rrkws : null,
                     ["after_upgrade"] = GetUpgradedInfo(cr.Card),
                 };
             }).ToList();
@@ -1627,6 +1741,7 @@ public class RunSimulator
             {
                 var stats = new Dictionary<string, object?>();
                 try { foreach (var dv in card.DynamicVars.Values) stats[dv.Name.ToLowerInvariant()] = (int)dv.BaseValue; } catch { }
+                var selkws = card.Keywords?.Where(k => k != CardKeyword.None).Select(k => k.ToString()).ToList();
                 return new Dictionary<string, object?>
                 {
                     ["index"] = i,
@@ -1634,9 +1749,11 @@ public class RunSimulator
                     ["name"] = _loc.Card(card.Id.Entry),
                     ["cost"] = card.EnergyCost?.GetResolved() ?? 0,
                     ["type"] = card.Type.ToString(),
+                    ["rarity"] = card.Rarity.ToString(),
                     ["upgraded"] = card.IsUpgraded,
                     ["stats"] = stats.Count > 0 ? stats : null,
                     ["description"] = _loc.Bilingual("cards", card.Id.Entry + ".description"),
+                    ["keywords"] = selkws?.Count > 0 ? selkws : null,
                     ["after_upgrade"] = GetUpgradedInfo(card),
                 };
             }).ToList();
@@ -1860,7 +1977,8 @@ public class RunSimulator
             }
             catch { }
 
-            var starCost = c.BaseStarCost;
+            // Use CurrentStarCost (combat-modified) for UI/can_play; BaseStarCost ignores temporary reductions.
+            var starCost = c.CurrentStarCost;
             var cardInfo = new Dictionary<string, object?>
             {
                 ["index"] = i,
@@ -1868,6 +1986,7 @@ public class RunSimulator
                 ["name"] = _loc.Card(c.Id.Entry),
                 ["cost"] = c.EnergyCost?.GetResolved() ?? 0,
                 ["type"] = c.Type.ToString(),
+                ["rarity"] = c.Rarity.ToString(),
                 ["can_play"] = c.CanPlay(out _, out _),
                 ["target_type"] = c.TargetType.ToString(),
                 ["stats"] = stats.Count > 0 ? stats : null,
@@ -2100,6 +2219,7 @@ public class RunSimulator
         {
             var stats = new Dictionary<string, object?>();
             try { foreach (var dv in c.DynamicVars.Values) stats[dv.Name.ToLowerInvariant()] = (int)dv.BaseValue; } catch { }
+            var crkws = c.Keywords?.Where(k => k != CardKeyword.None).Select(k => k.ToString()).ToList();
             return new Dictionary<string, object?>
             {
                 ["index"] = i,
@@ -2110,6 +2230,7 @@ public class RunSimulator
                 ["rarity"] = c.Rarity.ToString(),
                 ["description"] = _loc.Bilingual("cards", c.Id.Entry + ".description"),
                 ["stats"] = stats.Count > 0 ? stats : null,
+                ["keywords"] = crkws?.Count > 0 ? crkws : null,
                 ["after_upgrade"] = GetUpgradedInfo(c),
             };
         }).ToList();
@@ -2367,14 +2488,17 @@ public class RunSimulator
                     }
                 }
                 catch { }
+                var shopkws = card?.Keywords?.Where(k => k != CardKeyword.None).Select(k => k.ToString()).ToList();
                 return new Dictionary<string, object?>
                 {
                     ["index"] = i,
                     ["name"] = _loc.Card(entry),
                     ["type"] = card?.Type.ToString() ?? "?",
+                    ["rarity"] = card?.Rarity.ToString() ?? "?",
                     ["card_cost"] = cardCost,
                     ["description"] = _loc.Bilingual("cards", entry + ".description"),
                     ["stats"] = stats.Count > 0 ? stats : null,
+                    ["keywords"] = shopkws?.Count > 0 ? shopkws : null,
                     ["after_upgrade"] = card != null ? GetUpgradedInfo(card) : null,
                     ["cost"] = e.Cost,
                     ["is_stocked"] = e.IsStocked,
@@ -2484,6 +2608,11 @@ public class RunSimulator
 
             // Pump the synchronization context to execute any pending continuations
             _syncCtx.Pump();
+
+            // Executor may stay "running" while the game awaits headless card selection / reward (e.g. Attack Potion).
+            // Spinning here would time out and downstream code could mis-handle an in-flight potion use (BUG-026).
+            if (_cardSelector.HasPending || _cardSelector.HasPendingReward)
+                return;
 
             var executor = RunManager.Instance.ActionExecutor;
             if (executor.IsRunning)


### PR DESCRIPTION
## Summary
- **Program.cs**: Locate `lib/` without hardcoded `..` depth — `STS2_LIB` env, walk parents from `AppContext.BaseDirectory` for `sts2.dll`, fallback to `BaseDirectory/lib`.
- **RunSimulator.cs**:
  - Expected save `schema_version`: lazy resolve on `load_save` only (`STS2_SAVE_SCHEMA_VERSION` → reflect `GetLatestSchemaVersion` / `GetLatestVersion` in Saves → fallback + stderr).
  - `WaitForActionExecutor` returns early when headless card selection/reward is pending (potion flows that open `card_select`).
  - `DoUsePotion`: do not “manual discard” while that selection is still pending.
  - Regent / star cards: use `CurrentStarCost` for JSON `star_cost` and `can_play` override (was `BaseStarCost`).
  - Serialize `keywords` + `rarity` for shop, `card_select`, card rewards, bundle cards; add `rarity` on combat hand JSON.
- **play.py**:
  - `start_run` error → exit (avoid `proceed` loop / “No run in progress” spam).
  - Potion: prompt enemy target only when potion is `AnyEnemy`.
  - `card_select`: comma-separated indices, min/max validation, prompts + help mention pick count.
  - Card display: prefix keywords `[奇巧/保留/…]` before description, suffix (`消耗` etc.) on title row; multi-line desc tail; full `RARITY_ZH` incl. `Basic`; **no rarity on combat hand**; shared `print_card_detail_extension`.
- **launch.py**: Interactive launcher (new game / load save → `play.py`).
- **.gitignore**: `saves/*` (local saves — **drop this hunk if upstream prefers tracking `saves/`**).

## Test on WSL
- [X] `dotnet build src/Sts2Headless/Sts2Headless.csproj`
- [X] `python3 python/play.py` — new run, combat hand, potion that opens card pick, `card_select` with multi pick

## Notes / risks
- Save schema reflection may not find API on some DLL builds; `STS2_SAVE_SCHEMA_VERSION` documents override.
- `.gitignore` for `saves/` is optional for maintainers.