### PR TITLE
feat: add console bridge and command reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ obj/
 .DS_Store
 .obsidian/
 logs/
+.godot-user/

--- a/docs/console-commands.md
+++ b/docs/console-commands.md
@@ -1,0 +1,129 @@
+# STS2 Console Command Reference
+
+- Generated on: `2026-04-07`
+- Source: reflected from local `sts2.dll` via `dump_console_commands`
+- Coverage: `39` commands
+- Scope: this document describes the `console` bridge exposed by this workspace's `sts2-cli`, not a transcription of the game's GUI help overlay
+
+## How to use it
+
+- Raw game syntax: `fight SHRINKER_BEETLE_WEAK`
+- In this `sts2-cli` workspace: `console fight SHRINKER_BEETLE_WEAK`
+- All examples below use the CLI form: `console <command>`
+
+## Risk levels
+
+- `safe`: inspection, export, or local-path helpers with low gameplay risk
+- `stateful`: changes the current run, combat, map, resources, or UI state
+- `dangerous`: touches persistent progress, cloud saves, external services, or crash flows
+
+## Practical notes
+
+- Commands with `<id:string>` usually expect model IDs.
+- If you need IDs, start with `console dump`.
+- The bridge is confirmed working for: `gold`, `fight`, `event`, `room`, `card`, `relic`, `potion`, `upgrade`.
+- `act` exists and exports correctly, but is not stable in the current headless bridge.
+
+## Quick Index
+
+| Command | Category | Risk | Syntax | Tested |
+| --- | --- | --- | --- | --- |
+| `act` | Flow and navigation | `stateful` | `<int|string: act>` | Tested, bridge unstable |
+| `ancient` | Flow and navigation | `stateful` | `<id:string> <choice:string>` | Not tested |
+| `event` | Flow and navigation | `stateful` | `<id:string>` | Tested |
+| `fight` | Flow and navigation | `stateful` | `<id:string>` | Tested |
+| `multiplayer` | Flow and navigation | `stateful` | `none` | Not tested |
+| `room` | Flow and navigation | `stateful` | `<id:string>` | Tested |
+| `travel` | Flow and navigation | `stateful` | `none` | Not tested |
+| `power` | Combat and resources | `stateful` | `<id:string> <amount:int> <target-index:int>` | Not tested |
+| `block` | Combat and resources | `stateful` | `<amount:int> <target-index:int>` | Not tested |
+| `damage` | Combat and resources | `stateful` | `<amount:int> <target-index:int>` | Not tested |
+| `die` | Combat and resources | `stateful` | `none` | Not tested |
+| `draw` | Combat and resources | `stateful` | `<count:int>` | Not tested |
+| `energy` | Combat and resources | `stateful` | `<amount:int>` | Not tested |
+| `godmode` | Combat and resources | `stateful` | `none` | Not tested |
+| `gold` | Combat and resources | `stateful` | `<amount:int>` | Tested |
+| `heal` | Combat and resources | `stateful` | `<amount:int> [index:int]` | Not tested |
+| `instant` | Combat and resources | `stateful` | `none` | Not tested |
+| `kill` | Combat and resources | `stateful` | `<target-index:int>|'all'` | Not tested |
+| `stars` | Combat and resources | `stateful` | `<amount:int>` | Not tested |
+| `win` | Combat and resources | `stateful` | `none` | Not tested |
+| `afflict` | Cards, relics, and potions | `stateful` | `<id:string> [amount:int] [hand-index:int]` | Not tested |
+| `card` | Cards, relics, and potions | `stateful` | `<card-id:string> [pileName:string]` | Tested |
+| `enchant` | Cards, relics, and potions | `stateful` | `<id:string> [amount:int] [hand-index:int]` | Not tested |
+| `potion` | Cards, relics, and potions | `stateful` | `<id:string>` | Tested |
+| `relic` | Cards, relics, and potions | `stateful` | `[add|remove] <relic-id:string>` | Tested |
+| `remove_card` | Cards, relics, and potions | `stateful` | `<id:string> [pileName:string]` | Not tested |
+| `upgrade` | Cards, relics, and potions | `stateful` | `<hand-index:int>` | Tested |
+| `achievement` | Progress and unlocks | `dangerous` | `<operation:string> [id:string]` | Not tested |
+| `unlock` | Progress and unlocks | `dangerous` | `<type:string>` | Not tested |
+| `art` | Diagnostics and system | `safe` | `<type:string>` | Not tested |
+| `cloud` | Diagnostics and system | `dangerous` | `delete` | Not tested |
+| `dump` | Diagnostics and system | `safe` | `none` | Not tested |
+| `getlogs` | Diagnostics and system | `safe` | `<name:string>` | Not tested |
+| `leaderboard` | Diagnostics and system | `dangerous` | `[option:string] [name:string] <score:int> [count:int]` | Not tested |
+| `log` | Diagnostics and system | `stateful` | `[type:string] <level:string>` | Not tested |
+| `open` | Diagnostics and system | `safe` | `logs|saves|root|build-logs|loc-override` | Not tested |
+| `log-history` | Diagnostics and system | `safe` | `none` | Not tested |
+| `sentry` | Diagnostics and system | `dangerous` | `<test|message|exception|crash|status> [text]` | Not tested |
+| `trailer` | Diagnostics and system | `stateful` | `none` | Not tested |
+
+## Flow and Navigation
+
+- `act <int|string: act>`: jump to an act or replace the current act. `Tested`: bridge unstable in the current headless runtime.
+- `ancient <id:string> <choice:string>`: open an ancient event and immediately choose one option. Common IDs include `NEOW`, `OROBAS`, `PAEL`, `TEZCATARA`, `VAKUU`.
+- `event <id:string>`: jump to a specific event. `Tested`: `console event AROMA_OF_CHAOS`.
+- `fight <id:string>`: jump straight into a specific encounter. `Tested`: `console fight SHRINKER_BEETLE_WEAK`.
+- `multiplayer`: open the multiplayer menu. The built-in description also mentions a `test` argument even though `Args` is empty in the exported metadata.
+- `room <id:string>`: jump to a room type. Common values in the current bridge are `Monster`, `Elite`, `Boss`, `Treasure`, `Shop`, `Event`, `RestSite`, `Map`. `Tested`: `console room RestSite`.
+- `travel`: enable unrestricted map travel.
+
+## Combat and Resources
+
+- `power <id:string> <amount:int> <target-index:int>`: apply a power to a target by combat index.
+- `block <amount:int> <target-index:int>`: grant block to the player or a target. `0` is the player.
+- `damage <amount:int> <target-index:int>`: damage a target or all enemies if no target is provided by the game-side command.
+- `die`: immediately kill the current player.
+- `draw <count:int>`: draw cards, mainly useful in combat.
+- `energy <amount:int>`: add energy to the player.
+- `godmode`: enable invulnerability.
+- `gold <amount:int>`: manipulate player gold. `Tested`: `console gold 123` changed gold from `99` to `222`.
+- `heal <amount:int> [index:int]`: heal the player, with an optional target index exposed by the game metadata.
+- `instant`: enable instant mode to skip waits.
+- `kill <target-index:int>|'all'`: kill one target, the first target by default, or all targets with `all`.
+- `stars <amount:int>`: add stars to the player.
+- `win`: immediately win the current combat.
+
+## Cards, Relics, and Potions
+
+- `afflict <id:string> [amount:int] [hand-index:int]`: apply an affliction to a card in hand.
+- `card <card-id:string> [pileName:string]`: spawn a card into a pile, hand by default. Use screaming snake case such as `BODY_SLAM`. `Tested`: `console card BODY_SLAM hand` after starting combat.
+- `enchant <id:string> [amount:int] [hand-index:int]`: enchant a card in hand.
+- `potion <id:string>`: add a potion to the belt. Use screaming snake case such as `ENTROPIC_BREW`. `Tested`: `console potion ENTROPIC_BREW`.
+- `relic [add|remove] <relic-id:string>`: add or remove a relic, with `add` as the default behavior. `Tested`: `console relic add ANCHOR`.
+- `remove_card <id:string> [pileName:string]`: remove a card from the hand or deck.
+- `upgrade <hand-index:int>`: upgrade the card at a hand position, where `0` is the left-most card. `Tested`: `console upgrade 0` in combat.
+
+## Progress and Unlocks
+
+- `achievement <operation:string> [id:string]`: unlock or revoke achievements. If no ID is supplied, the game description says it applies to all achievements. High risk for real profiles.
+- `unlock <type:string>`: mark discovery or unlock progress for categories such as cards, potions, relics, monsters, events, epochs, ascensions, or `all`.
+
+## Diagnostics and System
+
+- `art <type:string>`: list content of a given type that is missing art. The built-in description calls out `affliction`, `card`, `enchantment`, `power`, and `relic`.
+- `cloud delete`: delete Steam Cloud save files when running through Steam. High-risk external side effect.
+- `dump`: print the model ID database to the console and logs. This is the best first step when you need valid `<id:string>` values.
+- `getlogs <name:string>`: gather logs, zip them, and open the containing directory.
+- `leaderboard [option:string] [name:string] <score:int> [count:int]`: upload scores or random leaderboard samples. External side effect.
+- `log [type:string] <level:string>`: change log levels. The built-in description lists types such as `Generic`, `Network`, `Actions`, `GameSync`, `VisualSync`, and levels such as `VeryDebug`, `Load`, `Debug`, `Info`, `Warn`, `Error`.
+- `open logs|saves|root|build-logs|loc-override`: open common local paths in the OS file browser.
+- `log-history`: save command history and open the directory that contains it.
+- `sentry <test|message|exception|crash|status> [text]`: exercise Sentry reporting. `crash confirm` can trigger a native crash and terminate the game.
+- `trailer`: toggle the trailer/UI visibility mode controlled by number keys and `+`/`-`.
+
+## Validated behavior in this workspace
+
+- `gold`, `fight`, `event`, `room`, `card`, `relic`, `potion`, and `upgrade` have all been exercised through `python/play.py` via the `console` bridge.
+- `act` is exported correctly but is still unstable in the current headless bridge.
+- `dangerous` commands such as `cloud`, `leaderboard`, `sentry`, `achievement`, and `unlock` were intentionally documented without live testing.

--- a/python/play.py
+++ b/python/play.py
@@ -1064,16 +1064,68 @@ def _draw_conn(buf, from_col, to_col, W):
         if 0 <= mid < len(buf):
             buf[mid] = ch
 
+def _print_console_result(resp):
+    """Render a short summary of a bridged console command."""
+    if not resp:
+        print(f"  {c(t('No response from console bridge.','控制台桥接没有返回结果。'), 'red')}")
+        return
+    if resp.get("type") == "error":
+        print(f"  {c(t('Console error:','控制台错误:'), 'red')} {resp.get('message', '?')}")
+        output = resp.get("output")
+        if output:
+            for line in str(output).splitlines():
+                print(f"    {line}")
+        return
+
+    console = resp.get("console") or {}
+    output = resp.get("output")
+    pieces = []
+    for key in ("Message", "Text", "Status", "Success", "IsSuccess", "Error"):
+        value = console.get(key)
+        if value not in (None, "", []):
+            pieces.append(f"{key}={value}")
+
+    if not pieces:
+        for key, value in console.items():
+            if key in ("result_type", "to_string") or value in (None, "", []):
+                continue
+            if isinstance(value, (str, int, float, bool)):
+                pieces.append(f"{key}={value}")
+            elif isinstance(value, list):
+                pieces.append(f"{key}=[{', '.join(str(v) for v in value[:5])}]")
+            if len(pieces) >= 4:
+                break
+
+    summary = " | ".join(pieces) if pieces else console.get("to_string", "ok")
+    if output:
+        header = f"  {c('[DevConsole]', 'yellow')}"
+        if pieces:
+            header += f" {summary}"
+        print(header)
+        for line in str(output).splitlines():
+            print(f"    {line}")
+        return
+
+    print(f"  {c('[DevConsole]', 'yellow')} {summary}")
+
+
+def _should_record_replay(cmd, record=True):
+    """Return True when a command should be persisted into replay saves."""
+    return bool(record and cmd.get("cmd") in {"action", "console"})
+
+
 def get_input(prompt, valid_options=None, state=None):
-    """Get user input with validation. Supports meta-commands: help, map, deck, potions."""
+    """Get user input with validation. Supports meta-commands like help/map/save/console."""
     while True:
         try:
-            raw = input(f"\n{c('>', 'green')} {prompt}: ").strip().lower()
+            raw_input = input(f"\n{c('>', 'green')} {prompt}: ").strip()
         except (EOFError, KeyboardInterrupt):
             raise _QuitRequested()
 
-        if not raw:
+        if not raw_input:
             continue
+
+        raw = raw_input.lower()
 
         # Meta-commands available at any prompt
         if raw == "help":
@@ -1088,6 +1140,7 @@ def get_input(prompt, valid_options=None, state=None):
     {c('quit', 'cyan')}     — 退出
     {c('save', 'cyan')}     — 存档
     {c('saves', 'cyan')}    — 查看存档列表
+    {c('console ...', 'cyan')} — 运行 console 命令
 
   {c('操作:', 'bold')}
     地图:    输入路径编号 (0, 1, 2)
@@ -1109,6 +1162,7 @@ def get_input(prompt, valid_options=None, state=None):
     {c('abandon', 'cyan')}  — abandon run (forfeit)
     {c('save', 'cyan')}     — save game
     {c('saves', 'cyan')}    — list saves
+    {c('console ...', 'cyan')} — run a console command
 
   {c('Actions:', 'bold')}
     Map:     path number (0, 1, 2)
@@ -1164,6 +1218,22 @@ def get_input(prompt, valid_options=None, state=None):
                 print(f"\n  {t('Load with:','读档命令:')} python3 play.py --load saves/{saves[0]['file']}")
             else:
                 print(f"  {t('No saves found.','没有找到存档。')}")
+            continue
+        if raw == "console" or raw == "dev":
+            print(f"  {t('Usage: console <command>','用法: console <命令>')}")
+            continue
+        if raw.startswith("console ") or raw.startswith("dev "):
+            if not hasattr(get_input, '_send'):
+                print(f"  {t('Console bridge unavailable.','控制台桥接不可用。')}")
+                continue
+            cmd_text = raw_input.split(None, 1)[1].strip()
+            resp = get_input._send({"cmd": "console", "input": cmd_text})
+            _print_console_result(resp)
+            new_state = resp.get("state") if isinstance(resp, dict) else None
+            if isinstance(state, dict) and isinstance(new_state, dict):
+                state.clear()
+                state.update(new_state)
+                return "__refresh__"
             continue
         if raw == "quit":
             raise _QuitRequested()
@@ -1297,7 +1367,7 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
 
     def send(cmd, record=True):
         logger.log_action(cmd)
-        if record and cmd.get("cmd") == "action":
+        if _should_record_replay(cmd, record):
             action_log.append(cmd)
         proc.stdin.write(json.dumps(cmd) + "\n")
         proc.stdin.flush()
@@ -1438,6 +1508,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                 else:
                     valid = {str(i): ch for i, ch in enumerate(choices)}
                     key = get_input(t("Choose path [number]", "选择路径 [编号]"), set(valid.keys()), state=state)
+                    if key == "__refresh__":
+                        continue
                     pick = valid[key]
 
                 state = send({"cmd": "action", "action": "select_map_node",
@@ -1468,6 +1540,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                         choice = "e"
                 else:
                     choice = get_input(t("Play card [index], (e)nd turn, (p0) potion", "出牌 [编号], (e)结束回合, (p0)药水"), set(valid.keys()) | {"help"}, state=state)
+                    if choice == "__refresh__":
+                        continue
                     if choice == "help":
                         print(f"  {t('Enter card index, e=end turn, p0=use potion 0', '输入卡牌编号，e=结束回合，p0=使用药水0')}")
                         continue
@@ -1493,6 +1567,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     # Ask for target if needed
                     if enemies:
                         tgt = get_input("Target enemy [index] or self (s)", state=state)
+                        if tgt == "__refresh__":
+                            continue
                         if tgt != "s" and tgt.isdigit():
                             args["target_index"] = int(tgt)
                     state = send({"cmd": "action", "action": "use_potion", "args": args})
@@ -1507,6 +1583,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                         else:
                             tgt = get_input("Target enemy [index]",
                                            {str(e["index"]) for e in enemies})
+                            if tgt == "__refresh__":
+                                continue
                             args["target_index"] = int(tgt)
                     state = send({"cmd": "action", "action": "play_card", "args": args})
 
@@ -1520,6 +1598,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = "0" if cards else "s"
                 else:
                     choice = get_input(t("Pick card [index] or (s)kip", "选择卡牌 [编号] 或 (s)跳过"), set(valid.keys()), state=state)
+                    if choice == "__refresh__":
+                        continue
 
                 if choice == "s":
                     state = send({"cmd": "action", "action": "skip_card_reward"})
@@ -1549,6 +1629,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = "0"
                 else:
                     choice = get_input(t("Choose pack [index]", "选择卡牌包 [编号]"), set(valid.keys()), state=state)
+                    if choice == "__refresh__":
+                        continue
                 state = send({"cmd": "action", "action": "select_bundle",
                              "args": {"bundle_index": int(choice)}})
 
@@ -1587,6 +1669,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = "0"
                 else:
                     choice = get_input(t("Choose card(s) [index] or (s)kip", "选择卡牌 [编号] 或 (s)跳过"), set(valid.keys()), state=state)
+                    if choice == "__refresh__":
+                        continue
 
                 if choice == "s":
                     state = send({"cmd": "action", "action": "skip_select"})
@@ -1616,6 +1700,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = "leave"
                 else:
                     choice = get_input(t("Buy [index/r0/p0/rm] or (leave)", "购买 [编号/r0/p0/rm] 或 (leave)离开"), state=state)
+                    if choice == "__refresh__":
+                        continue
 
                 if choice == "leave":
                     state = send({"cmd": "action", "action": "leave_room"})
@@ -1646,6 +1732,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = str(pick["index"]) if pick else "0"
                 else:
                     choice = get_input(t("Choose option [index]", "选择 [编号]"), set(valid.keys()), state=state)
+                    if choice == "__refresh__":
+                        continue
 
                 state = send({"cmd": "action", "action": "choose_option",
                              "args": {"option_index": int(choice)}})
@@ -1671,6 +1759,8 @@ def play(character="Ironclad", seed=None, auto=False, ascension=0, log=True,
                     choice = str(unlocked[0]["index"]) if unlocked else "leave"
                 else:
                     choice = get_input(t("Choose option [index] or (leave)", "选择 [编号] 或 (leave)离开"), set(valid.keys()), state=state)
+                    if choice == "__refresh__":
+                        continue
 
                 if choice == "leave":
                     state = send({"cmd": "action", "action": "leave_room"})

--- a/src/GodotStubs/Core.cs
+++ b/src/GodotStubs/Core.cs
@@ -157,20 +157,29 @@ public static class GD
 public static class OS
 {
     public static void ShellOpen(string uri) { }
+    public static Error ShellShowInFileManager(string path, bool openFolder = false) => Error.Unavailable;
     public static string GetLocale() => "en";
     public static string GetName() => "headless";
     public static string GetVersion() => "0.0";
     public static string GetExecutablePath() => "";
     public static bool HasFeature(string feature) => false;
     public static bool IsDebugBuild() => false;
-    public static string GetDataDir() => ".";
-    public static string GetUserDataDir() => ".";
+    public static string GetDataDir() => ProjectSettings.GlobalizePath("user://");
+    public static string GetUserDataDir() => ProjectSettings.GlobalizePath("user://");
     public static string[] GetCmdlineArgs() => Array.Empty<string>();
 }
 
 public static class ProjectSettings
 {
-    public static string GlobalizePath(string path) => path;
+    public static string GlobalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+        if (path.StartsWith("user://", StringComparison.OrdinalIgnoreCase))
+            return Path.Combine(Environment.CurrentDirectory, ".godot-user", path.Substring("user://".Length).Replace('/', Path.DirectorySeparatorChar));
+        if (path.StartsWith("res://", StringComparison.OrdinalIgnoreCase))
+            return Path.Combine(Environment.CurrentDirectory, path.Substring("res://".Length).Replace('/', Path.DirectorySeparatorChar));
+        return path;
+    }
     public static Variant GetSetting(string name, Variant @default = default) => @default;
     public static bool LoadResourcePack(string path) => false;
 }

--- a/src/GodotStubs/UI.cs
+++ b/src/GodotStubs/UI.cs
@@ -336,12 +336,108 @@ public class InputEventMouseMotion : InputEvent
 public class FileAccess : GodotObject, IDisposable
 {
     public enum ModeFlags { Read, Write, ReadWrite, WriteRead }
-    public static FileAccess? Open(string path, ModeFlags flags) => null;
-    public static bool FileExists(string path) => File.Exists(path);
-    public string GetAsText(bool skipCr = false) => "";
-    public void StoreString(string str) { }
-    public void Close() { }
-    public void Dispose() { }
+    private FileStream? _stream;
+    private StreamReader? _reader;
+    private StreamWriter? _writer;
+
+    private FileAccess(FileStream stream)
+    {
+        _stream = stream;
+    }
+
+    private static string ResolvePath(string path) => ProjectSettings.GlobalizePath(path);
+
+    public static FileAccess? Open(string path, ModeFlags flags)
+    {
+        try
+        {
+            var resolved = ResolvePath(path);
+            var dir = Path.GetDirectoryName(resolved);
+            if (!string.IsNullOrEmpty(dir) && flags != ModeFlags.Read)
+                Directory.CreateDirectory(dir);
+
+            var mode = flags switch
+            {
+                ModeFlags.Read => FileMode.Open,
+                ModeFlags.Write => FileMode.Create,
+                ModeFlags.ReadWrite => FileMode.OpenOrCreate,
+                ModeFlags.WriteRead => FileMode.Create,
+                _ => FileMode.OpenOrCreate,
+            };
+
+            var access = flags switch
+            {
+                ModeFlags.Read => System.IO.FileAccess.Read,
+                ModeFlags.Write => System.IO.FileAccess.Write,
+                ModeFlags.ReadWrite => System.IO.FileAccess.ReadWrite,
+                ModeFlags.WriteRead => System.IO.FileAccess.ReadWrite,
+                _ => System.IO.FileAccess.ReadWrite,
+            };
+
+            return new FileAccess(new FileStream(resolved, mode, access, FileShare.ReadWrite));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool FileExists(string path) => File.Exists(ResolvePath(path));
+
+    public ulong GetPosition() => (ulong)(_stream?.Position ?? 0);
+
+    public ulong GetLength() => (ulong)(_stream?.Length ?? 0);
+
+    public void Seek(ulong position)
+    {
+        if (_stream == null) return;
+        _stream.Position = (long)position;
+        _reader?.DiscardBufferedData();
+    }
+
+    public bool EofReached() => _stream == null || _stream.Position >= _stream.Length;
+
+    public string GetAsText(bool skipCr = false)
+    {
+        if (_stream == null || !_stream.CanRead) return "";
+        _reader ??= new StreamReader(_stream, System.Text.Encoding.UTF8, true, 1024, leaveOpen: true);
+        var text = _reader.ReadToEnd();
+        return skipCr ? text.Replace("\r", "") : text;
+    }
+
+    public string GetLine()
+    {
+        if (_stream == null || !_stream.CanRead) return "";
+        _reader ??= new StreamReader(_stream, System.Text.Encoding.UTF8, true, 1024, leaveOpen: true);
+        return _reader.ReadLine() ?? "";
+    }
+
+    public void StoreString(string str)
+    {
+        if (_stream == null || !_stream.CanWrite) return;
+        _writer ??= new StreamWriter(_stream, System.Text.Encoding.UTF8, 1024, leaveOpen: true);
+        _writer.Write(str);
+        _writer.Flush();
+    }
+
+    public bool StoreLine(string line)
+    {
+        StoreString(line + Environment.NewLine);
+        return true;
+    }
+
+    public void Close()
+    {
+        _writer?.Flush();
+        _writer?.Dispose();
+        _writer = null;
+        _reader?.Dispose();
+        _reader = null;
+        _stream?.Dispose();
+        _stream = null;
+    }
+
+    public void Dispose() => Close();
 }
 
 // DirAccess

--- a/src/Sts2Headless/Program.cs
+++ b/src/Sts2Headless/Program.cs
@@ -169,6 +169,15 @@ class Program
                 return sim.SaveCheckpoint(outputPath);
             }
 
+            case "console":
+            {
+                var input = cmd.TryGetProperty("input", out var inputElem) ? inputElem.GetString() : null;
+                return sim.ExecuteConsoleCommand(input);
+            }
+
+            case "dump_console_commands":
+                return sim.DumpConsoleCommands();
+
             case "quit":
             {
                 var outputPath = cmd.TryGetProperty("path", out var op) ? op.GetString() : null;

--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -27,6 +27,8 @@ using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Multiplayer.Serialization;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Unlocks;
+using MegaCrit.Sts2.Core.DevConsole;
+using MegaCrit.Sts2.Core.DevConsole.ConsoleCommands;
 
 namespace Sts2Headless;
 
@@ -207,6 +209,7 @@ public class RunSimulator
     // Pending bundle selection (Scroll Boxes: pick 1 of N packs)
     private IReadOnlyList<IReadOnlyList<CardModel>>? _pendingBundles;
     private TaskCompletionSource<IEnumerable<CardModel>>? _pendingBundleTcs;
+    private DevConsole? _devConsole;
 
     public Dictionary<string, object?> StartRun(string character, int ascension = 0, string? seed = null, string lang = "en")
     {
@@ -248,6 +251,7 @@ public class RunSimulator
             // Register event handlers for combat turn transitions
             CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
             CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
+            _devConsole = null;
 
             // Finalize starting relics
             RunManager.Instance.FinalizeStartingRelics().GetAwaiter().GetResult();
@@ -461,6 +465,119 @@ public class RunSimulator
         catch (Exception ex) { return ErrorWithTrace("SetDrawOrder failed", ex); }
     }
 
+    public Dictionary<string, object?> ExecuteConsoleCommand(string? input)
+    {
+        try
+        {
+            if (_runState == null) return Error("No run in progress");
+            if (string.IsNullOrWhiteSpace(input)) return Error("Provide 'input' for console command");
+
+            SynchronizationContext.SetSynchronizationContext(_syncCtx);
+
+            var stdOut = Console.Out;
+            var stdErr = Console.Error;
+            using var capturedOut = new StringWriter();
+            using var capturedErr = new StringWriter();
+
+            try
+            {
+                Console.SetOut(capturedOut);
+                Console.SetError(capturedErr);
+
+                _devConsole ??= new DevConsole(true);
+                var cmdResult = _devConsole.ProcessCommand(input);
+
+                _syncCtx.Pump();
+                WaitForActionExecutor();
+
+                var output = CombineConsoleOutput(capturedOut.ToString(), capturedErr.ToString());
+                var errorMessage = TryGetConsoleFailure(output);
+                if (!string.IsNullOrEmpty(errorMessage))
+                {
+                    var err = Error($"Console command failed: {errorMessage}");
+                    err["input"] = input;
+                    err["output"] = output;
+                    return err;
+                }
+
+                var result = new Dictionary<string, object?>
+                {
+                    ["type"] = "console_result",
+                    ["input"] = input,
+                    ["console"] = SerializeConsoleResult(cmdResult),
+                    ["state"] = DetectDecisionPoint(),
+                };
+
+                if (!string.IsNullOrWhiteSpace(output))
+                    result["output"] = output;
+
+                return result;
+            }
+            finally
+            {
+                Console.SetOut(stdOut);
+                Console.SetError(stdErr);
+            }
+        }
+        catch (Exception ex)
+        {
+            return ErrorWithTrace("ExecuteConsoleCommand failed", ex);
+        }
+    }
+
+    public Dictionary<string, object?> DumpConsoleCommands()
+    {
+        try
+        {
+            EnsureModelDbInitialized();
+
+            var commands = new List<Dictionary<string, object?>>();
+            foreach (var type in AbstractConsoleCmdSubtypes.All.OrderBy(t => t.FullName, StringComparer.Ordinal))
+            {
+                var entry = new Dictionary<string, object?>
+                {
+                    ["class_name"] = type.Name,
+                    ["type_name"] = type.FullName,
+                };
+
+                try
+                {
+                    var instance = Activator.CreateInstance(type) as AbstractConsoleCmd;
+                    if (instance == null)
+                    {
+                        entry["instantiate_error"] = "Activator returned null";
+                    }
+                    else
+                    {
+                        entry["cmd_name"] = instance.CmdName;
+                        entry["args"] = string.IsNullOrWhiteSpace(instance.Args) ? null : instance.Args;
+                        entry["description"] = string.IsNullOrWhiteSpace(instance.Description) ? null : instance.Description;
+                        entry["debug_only"] = instance.DebugOnly;
+                        entry["is_networked"] = instance.IsNetworked;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    var inner = ex.InnerException ?? ex;
+                    entry["instantiate_error"] = $"{inner.GetType().Name}: {inner.Message}";
+                }
+
+                commands.Add(entry);
+            }
+
+            return new Dictionary<string, object?>
+            {
+                ["type"] = "console_commands",
+                ["count"] = AbstractConsoleCmdSubtypes.Count,
+                ["commands"] = commands,
+            };
+        }
+        catch (Exception ex)
+        {
+            return ErrorWithTrace("DumpConsoleCommands failed", ex);
+        }
+    }
+
     // ─── Game actions ───
     public Dictionary<string, object?> LoadSave(string saveJson)
     {
@@ -492,6 +609,7 @@ public class RunSimulator
 
             CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
             CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
+            _devConsole = null;
             CardSelectCmd.UseSelector(_cardSelector);
             LocPatches._bundleSimRef = this;
 
@@ -3423,11 +3541,124 @@ public class RunSimulator
             if (RunManager.Instance.IsInProgress)
                 RunManager.Instance.CleanUp(graceful: true);
             _runState = null;
+            _devConsole = null;
         }
         catch (Exception ex)
         {
             Log($"CleanUp exception: {ex.Message}");
         }
+    }
+
+    private static Dictionary<string, object?> SerializeConsoleResult(CmdResult cmdResult)
+    {
+        var result = new Dictionary<string, object?>
+        {
+            ["result_type"] = cmdResult.GetType().FullName,
+            ["to_string"] = cmdResult.ToString(),
+        };
+
+        foreach (var prop in cmdResult.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            try
+            {
+                result[prop.Name] = MakeJsonFriendly(prop.GetValue(cmdResult));
+            }
+            catch (Exception ex)
+            {
+                result[prop.Name] = $"<error: {ex.GetType().Name}: {ex.Message}>";
+            }
+        }
+
+        foreach (var field in cmdResult.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (result.ContainsKey(field.Name)) continue;
+            try
+            {
+                result[field.Name] = MakeJsonFriendly(field.GetValue(cmdResult));
+            }
+            catch (Exception ex)
+            {
+                result[field.Name] = $"<error: {ex.GetType().Name}: {ex.Message}>";
+            }
+        }
+
+        return result;
+    }
+
+    private static string CombineConsoleOutput(string stdOut, string stdErr)
+    {
+        var parts = new List<string>();
+
+        static string Normalize(string text)
+        {
+            return text.Replace("\r\n", "\n").Trim();
+        }
+
+        var outText = Normalize(stdOut);
+        if (!string.IsNullOrWhiteSpace(outText))
+            parts.Add(outText);
+
+        var errText = Normalize(stdErr);
+        if (!string.IsNullOrWhiteSpace(errText))
+            parts.Add(errText);
+
+        return string.Join(Environment.NewLine, parts);
+    }
+
+    private static string? TryGetConsoleFailure(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        foreach (var rawLine in output.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrEmpty(line))
+                continue;
+
+            var isErrorLine =
+                line.StartsWith("[ERROR]", StringComparison.OrdinalIgnoreCase) ||
+                line.Contains("Exception:", StringComparison.Ordinal);
+
+            if (!isErrorLine)
+                continue;
+
+            while (line.StartsWith("[ERROR]", StringComparison.OrdinalIgnoreCase))
+                line = line.Substring("[ERROR]".Length).TrimStart();
+
+            return line;
+        }
+
+        return null;
+    }
+
+    private static object? MakeJsonFriendly(object? value)
+    {
+        if (value == null) return null;
+
+        var type = value.GetType();
+        if (type.IsPrimitive || value is string || value is decimal)
+            return value;
+        if (value is Enum)
+            return value.ToString();
+        if (value is IEnumerable<string> strings)
+            return strings.ToList();
+        if (value is System.Collections.IEnumerable seq && value is not string)
+        {
+            var items = new List<object?>();
+            foreach (var item in seq)
+            {
+                items.Add(MakeJsonFriendly(item));
+                if (items.Count >= 32)
+                {
+                    items.Add("...");
+                    break;
+                }
+            }
+            return items;
+        }
+
+        return value.ToString();
     }
 
     #endregion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,9 @@ class Game:
     def set_draw_order(self, cards):
         return self.send({"cmd": "set_draw_order", "cards": cards})
 
+    def console(self, input_text):
+        return self.send({"cmd": "console", "input": input_text})
+
     def close(self):
         try:
             self.proc.stdin.write('{"cmd":"quit"}\n')

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,95 @@
+"""Tests for the console bridge."""
+
+
+class TestConsoleMetadata:
+    def test_dump_console_commands_returns_expected_shape(self, game):
+        result = game.send({"cmd": "dump_console_commands"})
+
+        assert result["type"] == "console_commands"
+        assert "count" in result
+        assert "commands" in result
+        assert result["count"] == len(result["commands"])
+
+    def test_dump_console_commands_contains_known_commands(self, game):
+        result = game.send({"cmd": "dump_console_commands"})
+
+        cmd_names = {cmd["cmd_name"] for cmd in result["commands"] if cmd.get("cmd_name")}
+
+        assert {"gold", "fight", "act"}.issubset(cmd_names)
+
+    def test_dump_console_command_entries_have_expected_fields(self, game):
+        result = game.send({"cmd": "dump_console_commands"})
+
+        for entry in result["commands"]:
+            assert "class_name" in entry
+            assert "type_name" in entry
+            assert "cmd_name" in entry or "instantiate_error" in entry
+
+            if "instantiate_error" not in entry:
+                assert "debug_only" in entry
+                assert "is_networked" in entry
+                assert "args" in entry
+                assert "description" in entry
+
+
+class TestConsoleExecution:
+    def test_console_requires_input(self, game):
+        game.start(seed="console_req1")
+
+        result = game.send({"cmd": "console"})
+
+        assert result["type"] == "error"
+        assert "Provide 'input'" in result["message"]
+
+    def test_console_gold_updates_player_state(self, game):
+        game.start(seed="console_gold1")
+
+        result = game.console("gold 123")
+
+        assert result["type"] == "console_result"
+        assert result["state"]["player"]["gold"] == 222
+
+    def test_console_fight_transitions_to_combat_play(self, game):
+        game.start(seed="console_fight1")
+
+        result = game.console("fight SHRINKER_BEETLE_WEAK")
+
+        assert result["type"] == "console_result"
+        assert result["state"]["decision"] == "combat_play"
+        assert "hand" in result["state"]
+        assert "enemies" in result["state"]
+
+    def test_console_result_keeps_state_payload(self, game):
+        game.start(seed="console_state1")
+
+        result = game.console("gold 1")
+
+        assert result["type"] == "console_result"
+        assert "state" in result
+        assert isinstance(result["state"], dict)
+        assert "player" in result["state"]
+
+    def test_console_dump_returns_captured_output(self, game):
+        game.start(seed="console_dump1")
+
+        result = game.console("dump")
+
+        assert result["type"] == "console_result"
+        assert "output" in result
+        assert "EPOCHS" in result["output"]
+
+    def test_console_async_failure_returns_error(self, game):
+        game.start(seed="console_act1")
+
+        result = game.console("act 2")
+
+        assert result["type"] == "error"
+        assert "NullReferenceException" in result["message"]
+        assert "NextAct" in result["output"]
+
+    def test_console_file_manager_commands_do_not_raise_missing_method(self, game):
+        game.start(seed="console_open1")
+
+        result = game.console("open saves")
+
+        assert "MissingMethodException" not in result.get("message", "")

--- a/tests/test_play.py
+++ b/tests/test_play.py
@@ -26,3 +26,53 @@ def test_quit_save_defaults_to_save_dir(monkeypatch):
     assert path.startswith(play.SAVE_DIR)
     assert path.endswith(".save")
 
+
+def test_print_console_result_uses_to_string_fallback(capsys):
+    play._print_console_result({"console": {"to_string": "ok"}})
+
+    out = capsys.readouterr().out
+    assert "[DevConsole]" in out
+    assert "ok" in out
+
+
+def test_print_console_result_renders_captured_output(capsys):
+    play._print_console_result({"console": {"to_string": "ok"}, "output": "line one\nline two"})
+
+    out = capsys.readouterr().out
+    assert "[DevConsole]" in out
+    assert "line one" in out
+    assert "line two" in out
+
+
+def test_should_record_replay_includes_console_commands():
+    assert play._should_record_replay({"cmd": "action"}) is True
+    assert play._should_record_replay({"cmd": "console"}) is True
+    assert play._should_record_replay({"cmd": "get_map"}) is False
+    assert play._should_record_replay({"cmd": "console"}, record=False) is False
+
+
+def test_get_input_console_command_sends_bridge_request_and_refreshes_state(monkeypatch, capsys):
+    sent = []
+    original_state = {"decision": "event_choice", "player": {"gold": 99}}
+    refreshed_state = {"decision": "event_choice", "player": {"gold": 222}}
+
+    def fake_send(payload, record=True):
+        sent.append((payload, record))
+        return {
+            "type": "console_result",
+            "console": {"to_string": "ok"},
+            "state": refreshed_state,
+        }
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "console gold 123")
+    monkeypatch.setattr(play.get_input, "_send", fake_send, raising=False)
+
+    result = play.get_input("Choose option", state=original_state)
+
+    assert result == "__refresh__"
+    assert sent == [({"cmd": "console", "input": "gold 123"}, True)]
+    assert original_state == refreshed_state
+
+    out = capsys.readouterr().out
+    assert "[DevConsole]" in out
+    assert "ok" in out


### PR DESCRIPTION
## Summary

This PR adds a bridge to the game's built-in console so `sts2-cli` can execute console commands from headless mode and the terminal UI.

It also adds a generated English command reference based on reflected command metadata from `sts2.dll`.

## What Changed

- added `console` and `dump_console_commands` to the headless JSON protocol
- wired the bridge through `MegaCrit.Sts2.Core.DevConsole.DevConsole.ProcessCommand(...)`
- added the minimum Godot stub support required for console initialization in headless mode
- added `console ...` / `dev ...` support in `python/play.py`
- added `docs/console-commands.md`, covering 39 reflected console commands with CLI usage examples
- added console bridge coverage in `tests/test_console.py` and `tests/test_play.py`
- ignored `.godot-user/` so local test runs stay clean

## Review Fixes

- capture console stdout/stderr and return it through the bridge so `console dump` is usable from the CLI
- surface executor-side console failures as JSON errors instead of reporting stale success state
- record `console` commands in replay saves so CLI saves can be replayed faithfully
- stub `OS.ShellShowInFileManager(...)` in headless mode so `open saves` / `log-history` no longer crash with `MissingMethodException`
- expand Python-side rendering so captured console output and bridge errors are shown to the user

## Validation

- `~/.dotnet-arm64/dotnet build src/Sts2Headless/Sts2Headless.csproj`
- targeted `play` / `console` regression suite: `15 passed`
- smoke-tested `console gold 123` and confirmed player gold changed to `222`
- smoke-tested `console dump` and confirmed reflected model IDs are returned to the CLI
- smoke-tested `console act 2` and confirmed async failures are surfaced as `type="error"`
- smoke-tested `console open saves` and confirmed it no longer crashes in headless mode
- confirmed action replay saves now persist console mutations such as `{"cmd":"console","input":"gold 123"}`

## Notes

- this PR remains draft
- no separate issue is attached because the repository does not appear to require issue-first changes for feature PRs
