### PR TITLE
fix: correct lib/ directory path resolution for assembly loading

### DIFF
--- a/src/Sts2Headless/Program.cs
+++ b/src/Sts2Headless/Program.cs
@@ -28,9 +28,15 @@ class Program
         };
 
         // Set up assembly resolution to find game DLLs
-        var libDir = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "lib");
+        // AppContext.BaseDirectory = src/Sts2Headless/bin/Debug/net9.0/
+        // Need 5 levels up to reach project root where lib/ lives
+        var libDir = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "lib");
         if (!Directory.Exists(libDir))
-            libDir = Path.Combine(AppContext.BaseDirectory, "lib");
+        {
+            libDir = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "lib");
+            if (!Directory.Exists(libDir))
+                libDir = Path.Combine(AppContext.BaseDirectory, "lib");
+        }
 
         AssemblyLoadContext.Default.Resolving += (ctx, name) =>
         {


### PR DESCRIPTION
## Summary

- **Problem**: Running `python play.py` fails with "Failed to start simulator" because the .NET runtime cannot find `sts2.dll`. This happens when the game is installed on a non-default drive (e.g., `D:/SteamLibrary/...` instead of `C:/Program Files (x86)/Steam/...`), causing `play.py`'s auto-detection (`_find_game_dir`) to miss the game directory and leave `STS2_GAME_DIR` unset. The program then relies solely on the relative `lib/` path, which was miscalculated.
- **Root cause**: `AppContext.BaseDirectory` resolves to `src/Sts2Headless/bin/Debug/net9.0/`. The old code used 4 levels of `..` to find `lib/`, but that only reaches `src/` — not the project root. The correct traversal needs 5 levels: `net9.0 → Debug → bin → Sts2Headless → src → project root`.
- **Fix**: Try 5 levels first (correct path to project root), then fall back to 4 levels, then `AppContext.BaseDirectory/lib` for compatibility with other build layouts.

## Test plan

- [x] `dotnet build` succeeds (0 errors)
- [x] `dotnet run --no-build` outputs `{"type":"ready"}` without `FileNotFoundException`
- [x] `python play.py` starts the simulator successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)