### PR TITLE
Fix headless combat end_turn stalls across multiple encounters

### DIFF
--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -1041,6 +1041,22 @@ public class RunSimulator
             }
         }
 
+        if (!SpinWaitForCombatStable(maxIterations: 400, sleepMs: 10) &&
+            CombatManager.Instance.IsInProgress &&
+            !CombatManager.Instance.IsPlayPhase &&
+            player.Creature?.IsDead != true)
+        {
+            var stuckState = CombatManager.Instance.DebugOnlyGetState();
+            var stuckEnemies = stuckState?.Enemies?
+                .Where(e => e != null && e.IsAlive)
+                .Select(e => $"{e.Monster?.GetType().Name}(hp={e.CurrentHp})")
+                .ToList() ?? new();
+            return Error(
+                $"Combat did not stabilize after end_turn (round={stuckState?.RoundNumber ?? 0}, " +
+                $"play_phase={CombatManager.Instance.IsPlayPhase}, " +
+                $"enemies=[{string.Join(",", stuckEnemies)}])");
+        }
+
         return DetectDecisionPoint();
     }
 
@@ -1695,15 +1711,33 @@ public class RunSimulator
             {
                 return DetectPostCombatState(player, combatRoom);
             }
-            // Fallback: brief wait
-            for (int i = 0; i < 20; i++)
+            if (!SpinWaitForCombatStable())
             {
-                _syncCtx.Pump();
-                Thread.Sleep(5);
-                if (CombatManager.Instance.IsPlayPhase) return CombatPlayState(player);
-                if (!CombatManager.Instance.IsInProgress) return DetectPostCombatState(player, combatRoom);
+                var combatState = CombatManager.Instance.DebugOnlyGetState();
+                return Error(
+                    $"Combat did not reach a stable decision state (round={combatState?.RoundNumber ?? 0}, " +
+                    $"play_phase={CombatManager.Instance.IsPlayPhase}, " +
+                    $"in_progress={CombatManager.Instance.IsInProgress})");
             }
-            return CombatPlayState(player);
+
+            // Re-check after stabilization because pending card selections and combat
+            // completion can be created while pumping queued continuations.
+            if (_cardSelector.HasPending && _cardSelector.PendingOptions != null)
+            {
+                goto checkCardSelect;
+            }
+
+            if (CombatManager.Instance.IsInProgress && CombatManager.Instance.IsPlayPhase)
+            {
+                return CombatPlayState(player);
+            }
+
+            if (!CombatManager.Instance.IsInProgress || (player.Creature != null && player.Creature.IsDead))
+            {
+                return DetectPostCombatState(player, combatRoom);
+            }
+
+            return Error("Combat remained in an intermediate state");
         }
 
         // Event room
@@ -2504,18 +2538,31 @@ public class RunSimulator
         }
     }
 
-    private void SpinWaitForCombatStable()
+    private bool SpinWaitForCombatStable(int maxIterations = 200, int sleepMs = 5)
     {
-        int maxIterations = 200;
         for (int i = 0; i < maxIterations; i++)
         {
             _syncCtx.Pump();
-            if (!CombatManager.Instance.IsInProgress) return;
-            if (CombatManager.Instance.IsPlayPhase) return;
             WaitForActionExecutor();
-            if (CombatManager.Instance.IsPlayPhase || !CombatManager.Instance.IsInProgress) return;
-            Thread.Sleep(5);
+
+            if (!CombatManager.Instance.IsInProgress) return true;
+            if (CombatManager.Instance.IsPlayPhase) return true;
+            if (_cardSelector.HasPending && _cardSelector.PendingOptions != null) return true;
+
+            WaitForActionExecutor();
+            if (!CombatManager.Instance.IsInProgress) return true;
+            if (CombatManager.Instance.IsPlayPhase) return true;
+            if (_cardSelector.HasPending && _cardSelector.PendingOptions != null) return true;
+
+            Thread.Sleep(sleepMs);
         }
+
+        _syncCtx.Pump();
+        WaitForActionExecutor();
+
+        return !CombatManager.Instance.IsInProgress ||
+               CombatManager.Instance.IsPlayPhase ||
+               (_cardSelector.HasPending && _cardSelector.PendingOptions != null);
     }
 
     /// <summary>Compute what a card would look like after upgrading (stats + cost + description).</summary>
@@ -2685,6 +2732,12 @@ public class RunSimulator
         // because there's no Godot scene tree, causing the ActionExecutor to deadlock.
         PatchCmdWait();
 
+        // Patch purely visual low-HP vignette hooks to no-op in headless mode.
+        // Some enemy attacks transition the combat into the enemy side correctly, but
+        // then crash while trying to create UI-only VFX nodes. That aborts the enemy
+        // turn and leaves combat permanently between phases.
+        PatchHeadlessOnlyVfx();
+
         // Initialize localization system (needed for events, cards, etc.)
         InitLocManager();
 
@@ -2801,6 +2854,49 @@ public class RunSimulator
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[WARN] Failed to patch Cmd.Wait: {ex.Message}");
+        }
+    }
+
+    private static void PatchHeadlessOnlyVfx()
+    {
+        try
+        {
+            var harmony = new Harmony("sts2headless.vfx");
+            var coreAssembly = typeof(MegaCrit.Sts2.Core.Commands.CardPileCmd).Assembly;
+
+            var helperType = coreAssembly.GetType("MegaCrit.Sts2.Core.Nodes.Vfx.PlayerHurtVignetteHelper");
+            var helperPlay = helperType?.GetMethod("Play",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+                null, Type.EmptyTypes, null);
+            if (helperPlay != null)
+            {
+                var prefix = typeof(YieldPatches).GetMethod(nameof(YieldPatches.SkipVoidPrefix),
+                    BindingFlags.Static | BindingFlags.Public);
+                if (prefix != null)
+                {
+                    harmony.Patch(helperPlay, new HarmonyMethod(prefix));
+                    Console.Error.WriteLine("[INFO] Patched PlayerHurtVignetteHelper.Play() to no-op in headless mode");
+                }
+            }
+
+            var lowHpType = coreAssembly.GetType("MegaCrit.Sts2.Core.Nodes.Vfx.Ui.NLowHpBorderVfx");
+            var lowHpCreate = lowHpType?.GetMethod("Create",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
+                null, Type.EmptyTypes, null);
+            if (lowHpCreate != null)
+            {
+                var prefix = typeof(YieldPatches).GetMethod(nameof(YieldPatches.SkipReferenceReturnPrefix),
+                    BindingFlags.Static | BindingFlags.Public);
+                if (prefix != null)
+                {
+                    harmony.Patch(lowHpCreate, new HarmonyMethod(prefix));
+                    Console.Error.WriteLine("[INFO] Patched NLowHpBorderVfx.Create() to no-op in headless mode");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[WARN] Failed to patch headless-only VFX: {ex.Message}");
         }
     }
 
@@ -2966,6 +3062,14 @@ public class RunSimulator
         {
             __result = Task.CompletedTask;
             return false; // Skip original method
+        }
+
+        public static bool SkipVoidPrefix() => false;
+
+        public static bool SkipReferenceReturnPrefix(ref object? __result)
+        {
+            __result = null;
+            return false;
         }
     }
 

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -2,6 +2,115 @@
 import pytest
 
 
+def _combat_signature(state):
+    enemies = tuple(
+        (enemy.get("name"), enemy.get("hp"), enemy.get("block", 0))
+        for enemy in state.get("enemies", [])
+    )
+    return (
+        state.get("decision"),
+        state.get("round"),
+        state.get("energy"),
+        len(state.get("hand", [])),
+        enemies,
+        state.get("player", {}).get("hp"),
+    )
+
+
+def _step_autoish_run(game, state):
+    decision = state.get("decision")
+
+    if decision == "map_select":
+        choices = state.get("choices", [])
+        assert choices, "Expected at least one map choice"
+        player = state.get("player", {})
+        hp_ratio = player.get("hp", 1) / max(player.get("max_hp", 1), 1)
+        if hp_ratio < 0.4:
+            pick = next((choice for choice in choices if choice["type"] == "RestSite"), choices[0])
+        else:
+            pick = choices[0]
+        return game.act("select_map_node", col=pick["col"], row=pick["row"])
+
+    if decision == "event_choice":
+        options = [option for option in state["options"] if not option.get("is_locked")]
+        return game.act("choose_option", option_index=options[0]["index"])
+
+    if decision == "card_reward":
+        return game.act("select_card_reward", card_index=0)
+
+    if decision == "bundle_select":
+        return game.act("select_bundle", bundle_index=0)
+
+    if decision == "card_select":
+        if state.get("min_select", 0) == 0:
+            return game.act("skip_select")
+        return game.act("select_cards", indices="0")
+
+    if decision == "rest_site":
+        options = [option for option in state["options"] if option.get("is_enabled", True)]
+        heal = next((option for option in options if option.get("option_id") == "HEAL"), None)
+        pick = heal or options[0]
+        return game.act("choose_option", option_index=pick["index"])
+
+    if decision == "shop":
+        return game.act("leave_room")
+
+    return game.act("proceed")
+
+
+def _play_without_repeating_identical_combat_state(game, state, *, max_steps=120, max_repeats=2):
+    repeats = 0
+    last_signature = None
+
+    for _ in range(max_steps):
+        if state.get("decision") != "combat_play":
+            return state
+
+        signature = _combat_signature(state)
+        if signature == last_signature:
+            repeats += 1
+        else:
+            repeats = 0
+            last_signature = signature
+
+        assert repeats < max_repeats, f"Combat state repeated without progress: {signature}"
+
+        hand = state.get("hand", [])
+        energy = state.get("energy", 0)
+        playable = [card for card in hand if card.get("can_play") and card.get("cost", 99) <= energy]
+        if playable:
+            card = playable[0]
+            args = {"card_index": card["index"]}
+            if card.get("target_type") == "AnyEnemy" and state.get("enemies"):
+                args["target_index"] = state["enemies"][0]["index"]
+            state = game.act("play_card", **args)
+        else:
+            state = game.act("end_turn")
+
+    pytest.fail(f"Combat did not resolve within {max_steps} steps")
+
+
+def _advance_to_nibbit(game):
+    return _advance_to_enemy(game, character="Silent", seed="reward_probe_1", enemy_name="Nibbit")
+
+
+def _advance_to_enemy(game, *, character, seed, enemy_name, max_steps=250):
+    state = game.start(character=character, seed=seed)
+    state = game.skip_neow(state)
+
+    for _ in range(max_steps):
+        if state.get("decision") == "combat_play":
+            enemy_names = {enemy.get("name") for enemy in state.get("enemies", [])}
+            if enemy_name in enemy_names:
+                return state
+            state = _play_without_repeating_identical_combat_state(game, state, max_steps=80)
+            continue
+
+        state = _step_autoish_run(game, state)
+
+    pytest.fail(f"Did not reach the {enemy_name} combat for seed {seed}")
+
+
 class TestCombatStructure:
     def test_combat_play_fields(self, game):
         state = game.start(seed="cs1")
@@ -228,3 +337,60 @@ class TestCombatEdgeCases:
                 break
         assert state["decision"] == "game_over"
         assert state["victory"] is False
+
+    def test_reward_probe_nibbit_combat_does_not_repeat_identical_end_turn_state(self, game):
+        state = _advance_to_nibbit(game)
+
+        enemy_names = {enemy.get("name") for enemy in state.get("enemies", [])}
+        assert "Nibbit" in enemy_names
+
+        final_state = _play_without_repeating_identical_combat_state(game, state, max_steps=120)
+        assert final_state.get("type") != "error"
+
+    def test_console_fight_progresses_without_repeating_identical_state(self, game):
+        game.start(seed="ce_console_progress")
+
+        result = game.console("fight SHRINKER_BEETLE_WEAK")
+
+        assert result["type"] == "console_result"
+        state = result["state"]
+        assert state["decision"] == "combat_play"
+
+        final_state = _play_without_repeating_identical_combat_state(game, state, max_steps=80)
+        assert final_state.get("type") != "error"
+
+    def test_console_elite_fight_does_not_error_after_end_turn(self, game):
+        game.start(seed="ce_elite_progress")
+
+        result = game.console("fight BYGONE_EFFIGY_ELITE")
+
+        assert result["type"] == "console_result"
+        state = result["state"]
+        assert state["decision"] == "combat_play"
+
+        final_state = _play_without_repeating_identical_combat_state(game, state, max_steps=120)
+        assert final_state.get("type") != "error"
+
+    def test_event_probe_ceremonial_beast_does_not_error_after_end_turn(self, game):
+        state = _advance_to_enemy(
+            game,
+            character="Defect",
+            seed="event_probe_1",
+            enemy_name="Ceremonial Beast",
+            max_steps=300,
+        )
+
+        final_state = _play_without_repeating_identical_combat_state(game, state, max_steps=200)
+        assert final_state.get("type") != "error"
+
+    def test_console_phrog_parasite_elite_spawn_phase_does_not_stall(self, game):
+        game.start(seed="ce_phrog_progress")
+
+        result = game.console("fight PHROG_PARASITE_ELITE")
+
+        assert result["type"] == "console_result"
+        state = result["state"]
+        assert state["decision"] == "combat_play"
+
+        final_state = _play_without_repeating_identical_combat_state(game, state, max_steps=180)
+        assert final_state.get("type") != "error"


### PR DESCRIPTION
## Summary
- tighten headless combat stabilization after `end_turn` so we only emit a new decision once combat has genuinely advanced
- patch headless-only low-HP vignette VFX that were crashing enemy-turn progression in some elite/boss/spawn fights
- add deterministic regressions for the previously reported stall family

## Root cause
This turned out to be broader than stale `combat_play` emission alone. Some encounters advanced into the enemy turn correctly, then hit UI-only low-HP VFX paths that are invalid in headless mode. That aborted enemy-turn progression and left combat stuck between phases.

## Issues
- fixes #21
- also resolves the same failure family observed in #22, #17, and #15

## Tests
- `~/.dotnet-arm64/dotnet build src/Sts2Headless/Sts2Headless.csproj -v minimal`
- `python3 -m pytest -q tests/test_combat.py -k 'nibbit or ceremonial_beast or bygone or phrog or end_turn or console_fight_progresses_without_repeating_identical_state'`
- `python3 -m pytest -q tests/test_combat.py`
- `python3 -m pytest -q -k 'not slow'`

`not slow` still has the pre-existing `pytest.mark.slow` warning from `tests/test_characters.py`.
