### PR TITLE
fix: allow reusing one headless process across runs

### DIFF
--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -224,6 +224,8 @@ public class RunSimulator
     private int _goldBeforeCombat;
     private int _lastKnownHp;
     private readonly HeadlessCardSelector _cardSelector = new();
+    private IDisposable? _cardSelectorScope;
+    private bool _combatHandlersRegistered;
     // Pending bundle selection (Scroll Boxes: pick 1 of N packs)
     private IReadOnlyList<IReadOnlyList<CardModel>>? _pendingBundles;
     private TaskCompletionSource<IEnumerable<CardModel>>? _pendingBundleTcs;
@@ -232,6 +234,7 @@ public class RunSimulator
     {
         try
         {
+            CleanUp();
             _loc.Lang = lang;
             EnsureModelDbInitialized();
 
@@ -266,8 +269,12 @@ public class RunSimulator
             Log("Run launched");
 
             // Register event handlers for combat turn transitions
-            CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
-            CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
+            if (!_combatHandlersRegistered)
+            {
+                CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
+                CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
+                _combatHandlersRegistered = true;
+            }
 
             // Finalize starting relics
             RunManager.Instance.FinalizeStartingRelics().GetAwaiter().GetResult();
@@ -278,7 +285,7 @@ public class RunSimulator
             Log("Entered Act 0");
 
             // Register card selector for cards that need player choice
-            CardSelectCmd.UseSelector(_cardSelector);
+            _cardSelectorScope = CardSelectCmd.UseSelector(_cardSelector);
             LocPatches._bundleSimRef = this;
 
             // Now we should be at the map — detect decision point
@@ -486,6 +493,7 @@ public class RunSimulator
     {
         try
         {
+            CleanUp();
             _loc.Lang = lang;
             EnsureModelDbInitialized();
 
@@ -511,9 +519,13 @@ public class RunSimulator
             RunManager.Instance.SetUpSavedSinglePlayer(_runState, save);
             LocalContext.NetId = netService.NetId;
 
-            CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
-            CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
-            CardSelectCmd.UseSelector(_cardSelector);
+            if (!_combatHandlersRegistered)
+            {
+                CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
+                CombatManager.Instance.CombatEnded += _ => _combatEnded.Set();
+                _combatHandlersRegistered = true;
+            }
+            _cardSelectorScope = CardSelectCmd.UseSelector(_cardSelector);
             LocPatches._bundleSimRef = this;
 
             var savedRoom = _runState.CurrentRoom;
@@ -3094,6 +3106,21 @@ public class RunSimulator
             _rewardChoice = -1;
             _rewardWait?.Set();
         }
+
+        public void Reset()
+        {
+            var pendingTcs = _pendingTcs;
+            var rewardWait = _rewardWait;
+
+            PendingOptions = null;
+            _pendingTcs = null;
+            _rewardChoice = -1;
+            PendingRewardCards = null;
+            _rewardWait = null;
+
+            pendingTcs?.TrySetResult(Array.Empty<CardModel>());
+            rewardWait?.Set();
+        }
     }
 
     internal static class YieldPatches
@@ -3573,11 +3600,38 @@ public class RunSimulator
             if (RunManager.Instance.IsInProgress)
                 RunManager.Instance.CleanUp(graceful: true);
             _runState = null;
+            ResetPerRunFields();
         }
         catch (Exception ex)
         {
             Log($"CleanUp exception: {ex.Message}");
         }
+    }
+
+    private void ResetPerRunFields()
+    {
+        try
+        {
+            _cardSelectorScope?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Log($"Card selector dispose exception: {ex.Message}");
+        }
+        _cardSelectorScope = null;
+        CardSelectCmd.Reset();
+        _cardSelector.Reset();
+        _eventOptionChosen = false;
+        _lastEventOptionCount = 0;
+        _pendingRewards = null;
+        _pendingCardReward = null;
+        _rewardsProcessed = false;
+        _goldBeforeCombat = 0;
+        _lastKnownHp = 0;
+        _pendingBundles = null;
+        _pendingBundleTcs = null;
+        _turnStarted.Reset();
+        _combatEnded.Reset();
     }
 
     #endregion

--- a/tests/test_process_reuse.py
+++ b/tests/test_process_reuse.py
@@ -1,0 +1,14 @@
+"""Regression tests for reusing one headless process across runs."""
+
+
+def test_start_run_can_be_called_twice_in_one_process(game):
+    first = game.start(seed="reuse-first")
+    assert first["type"] == "decision"
+    assert first["decision"] == "event_choice"
+
+    second = game.start(seed="reuse-second")
+
+    assert second["type"] == "decision"
+    assert second["decision"] == "event_choice"
+    assert second["context"]["floor"] == 1
+    assert second["player"]["hp"] == second["player"]["max_hp"]


### PR DESCRIPTION
## Impact

For PPO-style workloads that start many episodes per worker, this reduces median run-start overhead from ~485 ms with a fresh CLI process to ~35 ms when reusing the same process, about a 14x faster reset/start path.

I measured this on this PR branch with a Release build against the same local `sts2.dll`: 12 cold process launches plus first `start_run`, and 40 repeated `start_run` calls in one already-running process.

## Summary

This allows the headless CLI process to handle more than one `start_run` call in the same process.

Before this change, a second `start_run` sent to the same process fails with:

```text
StartRun failed: InvalidOperationException: State is already set.
```

That makes callers launch a fresh CLI process for every run. For automation, testing, and training workloads, this adds avoidable overhead because each process has to reload the .NET runtime, game DLLs, localization, model data, and patches.

## Changes

- Call `CleanUp()` before `StartRun()` and `LoadSave()` install a new run.
- Reset per-run simulator fields during cleanup.
- Dispose/reset the active card selector registration.
- Avoid registering duplicate combat event handlers when a process is reused.
- Add a regression test that calls `start_run` twice in one `Game` process.

## Motivation

The expensive engine setup is process-level state and can be reused safely across independent game runs. The active `RunState`, pending decisions, rewards, bundle/card selectors, turn events, and related per-run fields should be cleared between runs.

This enables the pattern:

```text
start CLI process once
start run
play/inspect run
start another run in the same process
```

instead of:

```text
start CLI process
start run
exit CLI
start CLI process again
start run
```

## Tests

Added:

```text
tests/test_process_reuse.py::test_start_run_can_be_called_twice_in_one_process
```

Validation:

```text
pytest tests/test_process_reuse.py -q
# 1 passed

pytest -q -k 'not test_skip_card and not test_heal_caps_at_max'
# 56 passed, 2 deselected, 1 warning

dotnet build src/Sts2Headless/Sts2Headless.csproj -c Release
# Build succeeded
```

Note: `tests/test_card_reward.py::TestCardReward::test_skip_card` and `tests/test_rest_site.py::TestRestSiteActions::test_heal_caps_at_max` fail on clean upstream with my current game DLLs as well, so they appear unrelated to this change.
