### PR TITLE
fix: target player for AnyPlayer potions

### DIFF
--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -1445,9 +1445,11 @@ public class RunSimulator
         Creature? target = null;
         var potionTargetType = potion.TargetType;
 
-        // Self-targeting potions (Flex, Fortifier, etc.) ALWAYS target the player
+        // Player-targeting potions (Flex, Fortifier, Liquid Bronze, etc.) ALWAYS target the player
         // regardless of any target_index the caller provides
-        if (potionTargetType == TargetType.Self || potionTargetType == TargetType.TargetedNoCreature)
+        if (potionTargetType == TargetType.Self
+            || potionTargetType == TargetType.TargetedNoCreature
+            || potionTargetType == TargetType.AnyPlayer)
         {
             target = player.Creature;
         }
@@ -2072,6 +2074,7 @@ public class RunSimulator
                 // Enemy powers
                 var ePowers = e.Powers?.Select(pw => new Dictionary<string, object?>
                 {
+                    ["id"] = pw.Id.Entry,
                     ["name"] = _loc.Power(pw.Id.Entry),
                     ["description"] = _loc.Bilingual("powers", pw.Id.Entry + ".description"),
                     ["amount"] = pw.Amount,
@@ -2093,6 +2096,7 @@ public class RunSimulator
         // Player powers/buffs
         var playerPowers = player.Creature?.Powers?.Select(pw => new Dictionary<string, object?>
         {
+            ["id"] = pw.Id.Entry,
             ["name"] = _loc.Power(pw.Id.Entry),
             ["description"] = _loc.Bilingual("powers", pw.Id.Entry + ".description"),
             ["amount"] = pw.Amount,
@@ -2734,6 +2738,7 @@ public class RunSimulator
                 return new Dictionary<string, object?>
                 {
                     ["index"] = i,
+                    ["id"] = p.Id.Entry,
                     ["name"] = _loc.Potion(p.Id.Entry),
                     ["description"] = _loc.Bilingual("potions", p.Id.Entry + ".description"),
                     ["vars"] = pvars.Count > 0 ? pvars : null,

--- a/tests/test_potions.py
+++ b/tests/test_potions.py
@@ -1,0 +1,32 @@
+"""Tests for potion behavior."""
+
+
+class TestPotions:
+    def test_anyplayer_potion_targets_player(self, game):
+        state = game.start(seed="p3")
+        phial_holster = next(
+            (
+                option
+                for option in state["options"]
+                if option.get("text_key") == "NEOW.pages.INITIAL.options.PHIAL_HOLSTER"
+                and not option.get("is_locked")
+            ),
+            None,
+        )
+        assert phial_holster is not None
+
+        state = game.act("choose_option", option_index=phial_holster["index"])
+        state = game.skip_neow(state)
+
+        potions = state["player"]["potions"]
+        liquid_bronze = next(potion for potion in potions if potion["id"] == "LIQUID_BRONZE")
+        assert liquid_bronze["target_type"] == "AnyPlayer"
+
+        state = game.enter_room("combat", encounter="SHRINKER_BEETLE_WEAK")
+        state = game.act("use_potion", potion_index=liquid_bronze["index"])
+
+        player_powers = state.get("player_powers") or []
+        assert any(
+            power["id"] == "THORNS_POWER" and power["amount"] >= 3
+            for power in player_powers
+        )


### PR DESCRIPTION
## Summary

Fix `AnyPlayer` potions so the headless CLI targets the player creature when constructing `UsePotionAction`.

Before this change, an `AnyPlayer` potion such as Liquid Bronze could be consumed without applying its player-targeted effect. In the regression test, Liquid Bronze disappears from the potion list but no Thorns power is added.

## Changes

- Treat `TargetType.AnyPlayer` like other player-targeting potion types in `DoUsePotion`.
- Add stable `id` fields to serialized player potions and player/enemy powers, so tests and downstream agents do not need localized display names.
- Add a regression test using seed `p3`, selecting Phial Holster by its stable `text_key`.
- The test enters combat, uses `LIQUID_BRONZE`, and verifies the player gains `THORNS_POWER`.

## Tests

Red before the fix:

```text
pytest tests/test_potions.py -q
# failed: player_powers did not contain Thorns after Liquid Bronze was consumed
```

Green after the fix:

```text
pytest tests/test_potions.py -q
# 1 passed

pytest -q -k 'not test_skip_card and not test_heal_caps_at_max'
# 56 passed, 2 deselected, 1 warning

dotnet build src/Sts2Headless/Sts2Headless.csproj -c Release
# Build succeeded
```

Note: `tests/test_card_reward.py::TestCardReward::test_skip_card` and `tests/test_rest_site.py::TestRestSiteActions::test_heal_caps_at_max` fail on clean upstream with my current game DLLs as well, so I excluded them from the broader validation run.
