### PR TITLE
Fix startup and save loading against game v0.107.1

### DIFF
--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -517,7 +517,8 @@ public class RunSimulator
             Log($"RunState created, players={_runState.Players?.Count}");
 
             var netService = new NetSingleplayerGameService();
-            RunManager.Instance.SetUpSavedSinglePlayer(_runState, save);
+            // Renamed in v0.107.1: "Singleplayer", not "SinglePlayer".
+            _ = RunManager.Instance.SetUpSavedSingleplayer(_runState, save);
             LocalContext.NetId = netService.NetId;
 
             CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
@@ -3073,6 +3074,23 @@ public class RunSimulator
         _modelDbInitialized = true;
 
         TestMode.IsOn = true;
+
+        // v0.107.1: RunState.CreateForTest now reaches ModelDb.BadgeModels, which
+        // calls ReflectionHelper.ModTypes and throws "ModManager is not finished
+        // initializing!" while ModManager.State is None. ResetForTests() clears the
+        // mod list but leaves State at None, so set it to Skipped — "finished, with
+        // no mods", which is accurate headless. Without this every start_run fails.
+        try
+        {
+            MegaCrit.Sts2.Core.Modding.ModManager.ResetForTests();
+            typeof(MegaCrit.Sts2.Core.Modding.ModManager)
+                .GetProperty("State", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.SetValue(null, MegaCrit.Sts2.Core.Modding.ModManagerState.Skipped);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[WARN] ModManager init: {ex.Message}");
+        }
 
         // Install inline sync context on main thread
         SynchronizationContext.SetSynchronizationContext(_syncCtx);


### PR DESCRIPTION
Two API changes in Slay the Spire 2 **v0.107.1** stop the tool working. Both fixes are in `RunSimulator.cs`.

### 1. `start_run` fails for every seed

```
StartRun failed: InvalidOperationException: ModManager is not finished initializing!
ReflectionHelper.ModTypes cannot be called before that.
   at MegaCrit.Sts2.Core.Helpers.ReflectionHelper.get_ModTypes()
   at MegaCrit.Sts2.Core.Models.ModelDb.get_BadgeModels()
   at MegaCrit.Sts2.Core.Runs.RunState.CreateShared(...)
   at MegaCrit.Sts2.Core.Runs.RunState.CreateForTest(...)
```

`RunState.CreateForTest` now reaches `ModelDb.BadgeModels`, which calls `ReflectionHelper.ModTypes`, and that throws while `ModManager.State` is `None`.

`ModManager.ResetForTests()` clears the mod list but leaves `State` at `None`, so this sets it to `Skipped` — "finished, with no mods" — which is accurate for a headless run and lets initialization complete. The setter is private, hence the reflection; happy to switch to `ModManager.Initialize(...)` if you would rather construct the real arguments.

### 2. Build fails on the `load_save` path

`RunManager.SetUpSavedSinglePlayer` was renamed to `SetUpSaved**S**ingleplayer`. It also now returns a `Task`, so the result is explicitly discarded to keep the existing fire-and-forget behaviour.

### Verification

On Slay the Spire 2 v0.107.1 (commit `59260271`), Windows, .NET 9.0.317:

- `dotnet build src/Sts2Headless/Sts2Headless.csproj` — clean.
- `start_run` followed by `get_map` returns a full map for a given seed.

I have been using this to regenerate act maps from run-history seeds, and validated the output against 89 real runs: every walked path is consistent with the regenerated map, node type by node type.

### Note on `setup.sh` (not changed here)

On Windows the auto-detect points at the install root, but the DLLs are in `data_sts2_windows_x86_64/`. The `find` fallback does locate them, so it works, but passing the path explicitly is faster:

```bash
./setup.sh "C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/data_sts2_windows_x86_64"
```

The macOS branch already points into the equivalent `data_*` subdirectory, so the Windows one may just be an oversight. Left alone since I have only tested on Windows — happy to add it if useful.
