### PR TITLE
Fix Windows launcher setup

### DIFF
--- a/python/game_log.py
+++ b/python/game_log.py
@@ -50,7 +50,7 @@ class GameLogger:
         safe_seed = str(seed).replace("/", "_")
         filename = f"{ts}_{character}_{safe_seed}.jsonl"
         self._path = os.path.join(LOG_DIR, filename)
-        self._file = open(self._path, "w")
+        self._file = open(self._path, "w", encoding="utf-8")
 
     def log_state(self, state: dict):
         """Log a state/decision point received from the simulator."""

--- a/python/play.py
+++ b/python/play.py
@@ -17,6 +17,20 @@ import argparse
 import random
 from game_log import GameLogger
 
+
+def _configure_stdio():
+    """Keep Windows code pages from crashing on emoji/CJK output."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream and hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (OSError, ValueError):
+                pass
+
+
+_configure_stdio()
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT = os.path.join(ROOT, "src", "Sts2Headless", "Sts2Headless.csproj")
 LIB_DIR = os.path.join(ROOT, "lib")
@@ -26,11 +40,14 @@ SAVE_DIR = os.path.join(ROOT, "saves")
 def _find_dotnet():
     """Find .NET SDK binary."""
     candidates = [
+        os.environ.get("DOTNET"),
         os.path.expanduser("~/.dotnet-arm64/dotnet"),
         os.path.expanduser("~/.dotnet/dotnet"),
         "dotnet",
     ]
     for p in candidates:
+        if not p:
+            continue
         try:
             r = subprocess.run([p, "--version"], capture_output=True, text=True, timeout=5)
             if r.returncode == 0:

--- a/src/Sts2Headless/RunSimulator.cs
+++ b/src/Sts2Headless/RunSimulator.cs
@@ -517,7 +517,7 @@ public class RunSimulator
             Log($"RunState created, players={_runState.Players?.Count}");
 
             var netService = new NetSingleplayerGameService();
-            RunManager.Instance.SetUpSavedSinglePlayer(_runState, save);
+            RunManager.Instance.SetUpSavedSingleplayer(_runState, save);
             LocalContext.NetId = netService.NetId;
 
             CombatManager.Instance.TurnStarted += _ => _turnStarted.Set();
@@ -3073,6 +3073,7 @@ public class RunSimulator
         _modelDbInitialized = true;
 
         TestMode.IsOn = true;
+        InitializeEmptyModTypeCache();
 
         // Install inline sync context on main thread
         SynchronizationContext.SetSynchronizationContext(_syncCtx);
@@ -3148,6 +3149,34 @@ public class RunSimulator
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[WARN] ModelIdSerializationCache.Init: {ex.Message}");
+        }
+    }
+
+    private static void InitializeEmptyModTypeCache()
+    {
+        try
+        {
+            var helperType = typeof(ModelDb).Assembly.GetType("MegaCrit.Sts2.Core.Helpers.ReflectionHelper");
+            var getter = helperType?.GetProperty("ModTypes", BindingFlags.Static | BindingFlags.Public)?.GetGetMethod();
+            var prefix = typeof(YieldPatches).GetMethod(nameof(YieldPatches.ReflectionHelperModTypesPrefix),
+                BindingFlags.Static | BindingFlags.Public);
+            if (getter != null && prefix != null)
+            {
+                var harmony = new Harmony("sts2headless.modtypes");
+                harmony.Patch(getter, new HarmonyMethod(prefix));
+                Console.Error.WriteLine("[INFO] Patched ReflectionHelper.ModTypes to empty for headless");
+            }
+
+            var modTypesField = helperType?.GetField("_modTypes", BindingFlags.Static | BindingFlags.NonPublic);
+            if (modTypesField != null && modTypesField.GetValue(null) == null)
+            {
+                modTypesField.SetValue(null, Type.EmptyTypes);
+                Console.Error.WriteLine("[INFO] ReflectionHelper.ModTypes initialized empty for headless");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[WARN] ReflectionHelper.ModTypes init: {ex.Message}");
         }
     }
 
@@ -3442,6 +3471,12 @@ public class RunSimulator
         {
             __result = null;
             return false; // Skip original method
+        }
+
+        public static bool ReflectionHelperModTypesPrefix(ref Type[] __result)
+        {
+            __result = Type.EmptyTypes;
+            return false; // Skip ModManager initialization guard in no-mods headless mode.
         }
     }
 


### PR DESCRIPTION
## Summary
- Configure Python stdio and JSONL logging as UTF-8 so Windows code pages do not crash on Chinese/emoji output.
- Honor the DOTNET environment variable during SDK detection.
- Update headless compatibility with the current STS2 DLL by using SetUpSavedSingleplayer and bypassing ModManager mod-type initialization in no-mods headless mode.

## Testing
- dotnet build src/Sts2Headless/Sts2Headless.csproj
- python python/play.py --seed smoke-log